### PR TITLE
Add crypto package scaffolding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
   "click>=8.1",
   "rich>=13.0",
+  "argon2-cffi>=23.1.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pydantic>=2.0
 cryptography
 numpy
 rich
+argon2-cffi>=23.1.0
 python-dotenv
 pytest>=7.0
 pytest-cov

--- a/src/neuralstego/crypto/__init__.py
+++ b/src/neuralstego/crypto/__init__.py
@@ -1,0 +1,27 @@
+"""Cryptographic primitives and helpers for :mod:`neuralstego`."""
+
+from . import api
+from .aead import AEADCiphertext, decrypt, encrypt, generate_key
+from .envelope import Envelope, EnvelopeComponents, open_envelope, seal_envelope
+from .errors import AEADError, CryptoError, EnvelopeError, KDFError
+from .kdf import Argon2idParams, PBKDF2Params, derive_key, generate_salt
+
+__all__ = [
+    "AEADCiphertext",
+    "AEADError",
+    "Argon2idParams",
+    "CryptoError",
+    "Envelope",
+    "EnvelopeComponents",
+    "EnvelopeError",
+    "KDFError",
+    "PBKDF2Params",
+    "api",
+    "decrypt",
+    "derive_key",
+    "encrypt",
+    "generate_key",
+    "generate_salt",
+    "open_envelope",
+    "seal_envelope",
+]

--- a/src/neuralstego/crypto/aead.py
+++ b/src/neuralstego/crypto/aead.py
@@ -1,0 +1,64 @@
+"""Authenticated encryption with associated data (AEAD) helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from secrets import token_bytes
+from typing import Final
+
+from .errors import AEADError
+
+__all__ = [
+    "AEADCiphertext",
+    "DEFAULT_NONCE_SIZE",
+    "DEFAULT_TAG_SIZE",
+    "decrypt",
+    "encrypt",
+    "generate_key",
+]
+
+DEFAULT_KEY_SIZE: Final[int] = 32
+DEFAULT_NONCE_SIZE: Final[int] = 12
+DEFAULT_TAG_SIZE: Final[int] = 16
+
+
+@dataclass(frozen=True)
+class AEADCiphertext:
+    """Container for AEAD ciphertext components."""
+
+    nonce: bytes
+    ciphertext: bytes
+    tag: bytes
+
+
+def generate_key(size: int = DEFAULT_KEY_SIZE) -> bytes:
+    """Return a new random AEAD key."""
+
+    if size <= 0:
+        raise AEADError("AEAD key size must be positive.")
+    return token_bytes(size)
+
+
+def encrypt(
+    key: bytes,
+    plaintext: bytes,
+    *,
+    associated_data: bytes | None = None,
+) -> AEADCiphertext:
+    """Encrypt ``plaintext`` using an AEAD scheme.
+
+    The concrete implementation is intentionally left for future work.
+    """
+
+    raise NotImplementedError("AEAD encryption has not been implemented yet.")
+
+
+def decrypt(
+    key: bytes,
+    ciphertext: AEADCiphertext,
+    *,
+    associated_data: bytes | None = None,
+) -> bytes:
+    """Decrypt ``ciphertext`` previously produced by :func:`encrypt`."""
+
+    raise NotImplementedError("AEAD decryption has not been implemented yet.")

--- a/src/neuralstego/crypto/api.py
+++ b/src/neuralstego/crypto/api.py
@@ -1,0 +1,81 @@
+"""High-level API for orchestrating cryptographic operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from .aead import decrypt, encrypt
+from .envelope import Envelope, EnvelopeComponents, seal_envelope, open_envelope
+from .kdf import (
+    Argon2idParams,
+    KDFBackend,
+    PBKDF2Params,
+    derive_key,
+    generate_salt,
+)
+
+__all__ = [
+    "KeyDerivationSpec",
+    "encrypt_message",
+    "decrypt_message",
+]
+
+DEFAULT_KEY_LENGTH: Final[int] = 32
+
+
+@dataclass(frozen=True)
+class KeyDerivationSpec:
+    """Configuration controlling password-based key derivation."""
+
+    backend: KDFBackend | None = None
+    argon2_params: Argon2idParams | None = None
+    pbkdf2_params: PBKDF2Params | None = None
+    length: int = DEFAULT_KEY_LENGTH
+    salt_size: int = 16
+
+
+def encrypt_message(
+    password: bytes,
+    plaintext: bytes,
+    *,
+    associated_data: bytes | None = None,
+    kdf_spec: KeyDerivationSpec | None = None,
+) -> Envelope:
+    """Encrypt ``plaintext`` with a password-derived key."""
+
+    spec = kdf_spec or KeyDerivationSpec()
+    salt = generate_salt(spec.salt_size)
+    key = derive_key(
+        password,
+        salt,
+        length=spec.length,
+        backend=spec.backend,
+        argon2_params=spec.argon2_params,
+        pbkdf2_params=spec.pbkdf2_params,
+    )
+    ciphertext = encrypt(key, plaintext, associated_data=associated_data)
+    components = EnvelopeComponents(salt=salt, ciphertext=ciphertext)
+    return seal_envelope(components)
+
+
+def decrypt_message(
+    password: bytes,
+    envelope: Envelope,
+    *,
+    associated_data: bytes | None = None,
+    kdf_spec: KeyDerivationSpec | None = None,
+) -> bytes:
+    """Decrypt ``envelope`` with a password-derived key."""
+
+    spec = kdf_spec or KeyDerivationSpec()
+    components = open_envelope(envelope)
+    key = derive_key(
+        password,
+        components.salt,
+        length=spec.length,
+        backend=spec.backend,
+        argon2_params=spec.argon2_params,
+        pbkdf2_params=spec.pbkdf2_params,
+    )
+    return decrypt(key, components.ciphertext, associated_data=associated_data)

--- a/src/neuralstego/crypto/envelope.py
+++ b/src/neuralstego/crypto/envelope.py
@@ -1,0 +1,58 @@
+"""Envelope encryption orchestration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from .aead import AEADCiphertext
+from .errors import EnvelopeError
+
+__all__ = [
+    "Envelope",
+    "EnvelopeComponents",
+    "DEFAULT_SALT_SIZE",
+    "open_envelope",
+    "seal_envelope",
+]
+
+DEFAULT_SALT_SIZE: Final[int] = 16
+
+
+@dataclass(frozen=True)
+class EnvelopeComponents:
+    """Discrete building blocks used to construct an envelope."""
+
+    salt: bytes
+    ciphertext: AEADCiphertext
+
+
+@dataclass(frozen=True)
+class Envelope:
+    """Serialized representation of an encrypted payload."""
+
+    salt: bytes
+    nonce: bytes
+    ciphertext: bytes
+    tag: bytes
+
+
+def seal_envelope(components: EnvelopeComponents) -> Envelope:
+    """Bundle derived materials into an :class:`Envelope` structure."""
+
+    if not components.salt:
+        raise EnvelopeError("Envelope salt must be non-empty.")
+    if not components.ciphertext.nonce or not components.ciphertext.tag:
+        raise EnvelopeError("Envelope ciphertext components must be populated.")
+    return Envelope(
+        salt=components.salt,
+        nonce=components.ciphertext.nonce,
+        ciphertext=components.ciphertext.ciphertext,
+        tag=components.ciphertext.tag,
+    )
+
+
+def open_envelope(envelope: Envelope) -> EnvelopeComponents:
+    """Invert :func:`seal_envelope` by recreating the component bundle."""
+
+    raise NotImplementedError("Envelope opening logic has not been implemented yet.")

--- a/src/neuralstego/crypto/errors.py
+++ b/src/neuralstego/crypto/errors.py
@@ -1,0 +1,26 @@
+"""Exception hierarchy for the :mod:`neuralstego.crypto` package."""
+
+from __future__ import annotations
+
+__all__ = [
+    "CryptoError",
+    "KDFError",
+    "AEADError",
+    "EnvelopeError",
+]
+
+
+class CryptoError(Exception):
+    """Base exception for all cryptographic failures within the project."""
+
+
+class KDFError(CryptoError):
+    """Raised when a key-derivation operation fails or misbehaves."""
+
+
+class AEADError(CryptoError):
+    """Raised for authenticated encryption and decryption errors."""
+
+
+class EnvelopeError(CryptoError):
+    """Raised when envelope encryption orchestration fails."""

--- a/src/neuralstego/crypto/kdf.py
+++ b/src/neuralstego/crypto/kdf.py
@@ -1,0 +1,129 @@
+"""Key-derivation functions and helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import pbkdf2_hmac
+from importlib import import_module
+from importlib.util import find_spec
+from secrets import token_bytes
+from typing import Any, Final, Literal, Protocol, runtime_checkable
+
+from .errors import KDFError
+
+__all__ = [
+    "Argon2idParams",
+    "PBKDF2Params",
+    "KDFBackend",
+    "derive_key",
+    "generate_salt",
+]
+
+DEFAULT_SALT_SIZE: Final[int] = 16
+
+KDFBackend = Literal["argon2id", "pbkdf2"]
+
+
+@dataclass(frozen=True)
+class Argon2idParams:
+    """Tunable parameters for the Argon2id key derivation function."""
+
+    time_cost: int = 4
+    """Number of iterations (the ``t`` parameter)."""
+
+    memory_cost: int = 102_400
+    """Memory usage in kibibytes (the ``m`` parameter)."""
+
+    parallelism: int = 8
+    """Number of parallel lanes (the ``p`` parameter)."""
+
+
+@dataclass(frozen=True)
+class PBKDF2Params:
+    """Parameters controlling PBKDF2 when Argon2id is unavailable."""
+
+    iterations: int = 600_000
+    """Number of iterations for PBKDF2."""
+
+    hash_name: Literal["sha256", "sha512"] = "sha256"
+    """Digest algorithm to use with PBKDF2."""
+
+
+@runtime_checkable
+class _Argon2HashFn(Protocol):
+    """Runtime protocol describing the :mod:`argon2.low_level` API we consume."""
+
+    def __call__(
+        self,
+        secret: bytes,
+        salt: bytes,
+        time_cost: int,
+        memory_cost: int,
+        parallelism: int,
+        hash_len: int,
+        type: Any,
+        version: int = 19,
+    ) -> bytes:
+        ...
+
+
+def _load_argon2() -> tuple[_Argon2HashFn | None, Any]:
+    """Load Argon2 primitives if available, otherwise return ``(None, None)``."""
+
+    if find_spec("argon2") is None or find_spec("argon2.low_level") is None:
+        return None, None
+
+    module = import_module("argon2.low_level")
+    hash_secret_raw = getattr(module, "hash_secret_raw")
+    argon2_type = getattr(module, "Type")
+    if isinstance(hash_secret_raw, _Argon2HashFn):
+        return hash_secret_raw, getattr(argon2_type, "ID")
+    return None, None
+
+
+_HASH_SECRET_RAW, _ARGON2_TYPE_ID = _load_argon2()
+
+
+def generate_salt(size: int = DEFAULT_SALT_SIZE) -> bytes:
+    """Return a cryptographically secure random salt of ``size`` bytes."""
+
+    if size <= 0:
+        raise KDFError("Salt size must be a positive integer.")
+    return token_bytes(size)
+
+
+def derive_key(
+    secret: bytes,
+    salt: bytes,
+    *,
+    length: int,
+    backend: KDFBackend | None = None,
+    argon2_params: Argon2idParams | None = None,
+    pbkdf2_params: PBKDF2Params | None = None,
+) -> bytes:
+    """Derive a symmetric key using the requested backend."""
+
+    if length <= 0:
+        raise KDFError("Derived key length must be positive.")
+    chosen_backend: KDFBackend
+    if backend is not None:
+        chosen_backend = backend
+    else:
+        chosen_backend = "argon2id" if _HASH_SECRET_RAW is not None else "pbkdf2"
+
+    if chosen_backend == "argon2id":
+        if _HASH_SECRET_RAW is None or _ARGON2_TYPE_ID is None:
+            raise KDFError("Argon2id backend requested but argon2-cffi is unavailable.")
+        params = argon2_params or Argon2idParams()
+        return _HASH_SECRET_RAW(
+            secret,
+            salt,
+            time_cost=params.time_cost,
+            memory_cost=params.memory_cost,
+            parallelism=params.parallelism,
+            hash_len=length,
+            type=_ARGON2_TYPE_ID,
+        )
+
+    params = pbkdf2_params or PBKDF2Params()
+    return pbkdf2_hmac(params.hash_name, secret, salt, params.iterations, dklen=length)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration for ensuring the src layout is importable."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/crypto/test_aead.py
+++ b/tests/crypto/test_aead.py
@@ -1,0 +1,16 @@
+"""Placeholder tests for the AEAD helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from neuralstego.crypto import aead
+
+
+@pytest.mark.xfail(reason="AEAD implementation pending", strict=False)
+def test_encrypt_decrypt_roundtrip() -> None:
+    """Encryption and decryption should eventually round-trip."""
+
+    key = aead.generate_key()
+    ciphertext = aead.encrypt(key, b"secret")
+    assert aead.decrypt(key, ciphertext) == b"secret"

--- a/tests/crypto/test_api_roundtrip.py
+++ b/tests/crypto/test_api_roundtrip.py
@@ -1,0 +1,15 @@
+"""Placeholder tests for the high-level crypto API."""
+
+from __future__ import annotations
+
+import pytest
+
+from neuralstego.crypto import api
+
+
+@pytest.mark.xfail(reason="High-level API pending", strict=False)
+def test_api_encrypt_decrypt_roundtrip() -> None:
+    """The API should eventually support encryption round-trips."""
+
+    envelope = api.encrypt_message(b"password", b"payload")
+    assert api.decrypt_message(b"password", envelope) == b"payload"

--- a/tests/crypto/test_envelope.py
+++ b/tests/crypto/test_envelope.py
@@ -1,0 +1,19 @@
+"""Placeholder tests for the envelope orchestration layer."""
+
+from __future__ import annotations
+
+import pytest
+
+from neuralstego.crypto import aead, envelope
+
+
+@pytest.mark.xfail(reason="Envelope opening pending", strict=False)
+def test_open_envelope_roundtrip() -> None:
+    """Envelopes should support round-tripping once implemented."""
+
+    ciphertext = envelope.EnvelopeComponents(
+        salt=b"saltsalt",
+        ciphertext=aead.AEADCiphertext(nonce=b"\x00" * 12, ciphertext=b"", tag=b"\x00" * 16),
+    )
+    sealed = envelope.seal_envelope(ciphertext)
+    assert envelope.open_envelope(sealed) == ciphertext

--- a/tests/crypto/test_kdf.py
+++ b/tests/crypto/test_kdf.py
@@ -1,0 +1,19 @@
+"""Tests for the :mod:`neuralstego.crypto.kdf` module."""
+
+from __future__ import annotations
+
+from neuralstego.crypto.kdf import PBKDF2Params, derive_key
+
+
+def test_derive_key_with_pbkdf2_backend() -> None:
+    """PBKDF2 backend should derive a key of the requested length."""
+
+    params = PBKDF2Params(iterations=1000)
+    key = derive_key(
+        b"password",
+        salt=b"saltsalt",
+        length=32,
+        backend="pbkdf2",
+        pbkdf2_params=params,
+    )
+    assert len(key) == 32


### PR DESCRIPTION
## Summary
- add a typed `neuralstego.crypto` package with error hierarchy, KDF helper, AEAD/envelope stubs, and a high-level API facade
- introduce pytest scaffolding for the crypto components (xfailing placeholders plus a PBKDF2 fallback check)
- declare the argon2-cffi dependency and ensure the test suite can import the src layout

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4c43b8644833280b75a1cf69919e9