### PR TITLE
Fix arithmetic codec cutoff when no probabilities fall below threshold

### DIFF
--- a/tests/codec/test_arithmetic_threshold.py
+++ b/tests/codec/test_arithmetic_threshold.py
@@ -1,0 +1,58 @@
+"""Tests for arithmetic coding threshold handling."""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Callable
+
+import torch
+
+
+def _load_arithmetic_helper() -> Callable[[torch.Tensor, float, int], int]:
+    """Load the private helper from ``arithmetic.py`` without package installs."""
+
+    module_path = Path(__file__).resolve().parents[2] / "arithmetic.py"
+    spec = importlib.util.spec_from_file_location("arithmetic", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError("Unable to load arithmetic module for testing")
+
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert isinstance(loader, importlib.abc.Loader)
+
+    repo_root = str(Path(__file__).resolve().parents[2])
+    sys.path.insert(0, repo_root)
+    try:
+        loader.exec_module(module)
+    finally:
+        sys.path.remove(repo_root)
+
+    helper = getattr(module, "_select_cutoff_k")
+    if not callable(helper):
+        raise AttributeError("_select_cutoff_k is not callable")
+
+    return helper
+
+
+_select_cutoff_k = _load_arithmetic_helper()
+
+
+def test_select_cutoff_k_handles_absent_threshold() -> None:
+    """When no probabilities are below the threshold, fall back to full vocab."""
+
+    probs = torch.tensor([0.4, 0.35, 0.25], dtype=torch.float64)
+    k = _select_cutoff_k(probs, threshold=0.1, topk=50)
+
+    assert k == 3
+
+
+def test_select_cutoff_k_respects_topk_limit() -> None:
+    """Ensure the top-k cap is still honoured when a fallback occurs."""
+
+    probs = torch.tensor([0.4, 0.35, 0.25], dtype=torch.float64)
+    k = _select_cutoff_k(probs, threshold=0.1, topk=2)
+
+    assert k == 2


### PR DESCRIPTION
## Summary
- add a helper to safely compute the arithmetic codec cutoff and document the API
- use the helper inside encode/decode so empty threshold matches no longer raise
- cover the new behaviour with regression tests for the cutoff selection logic

## Testing
- pytest tests/codec

------
https://chatgpt.com/codex/tasks/task_e_68e4f43a4ca88332993092a9eadac9c6