### PR TITLE
Integrate GPT2 Transformers LM into arithmetic coding pipeline

### DIFF
--- a/src/neuralstego/crypto/__init__.py
+++ b/src/neuralstego/crypto/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from .aead import NONCE_SIZE, TAG_SIZE, aes_gcm_decrypt, aes_gcm_encrypt
 from .api import decrypt_message, encrypt_message
+from .arithmetic import decode_with_lm, encode_with_lm
+from .distribution import TransformersLM
 from .envelope import ENVELOPE_VERSION, pack_envelope, unpack_envelope
 from .errors import DecryptionError, EncryptionError, EnvelopeError, KDFError
 from .kdf import (
@@ -33,4 +35,7 @@ __all__ = [
     "pack_envelope",
     "unpack_envelope",
     "ENVELOPE_VERSION",
+    "TransformersLM",
+    "encode_with_lm",
+    "decode_with_lm",
 ]

--- a/src/neuralstego/crypto/arithmetic.py
+++ b/src/neuralstego/crypto/arithmetic.py
@@ -1,0 +1,7 @@
+"""Arithmetic coding helpers bound to language model providers."""
+
+from __future__ import annotations
+
+from ..codec.arithmetic import decode_with_lm, encode_with_lm
+
+__all__ = ["encode_with_lm", "decode_with_lm"]

--- a/src/neuralstego/crypto/distribution.py
+++ b/src/neuralstego/crypto/distribution.py
@@ -1,0 +1,7 @@
+"""Integration helpers for cryptographic pipelines using language models."""
+
+from __future__ import annotations
+
+from ..codec.distribution import TransformersLM
+
+__all__ = ["TransformersLM"]

--- a/tests/crypto/test_arithmetic_gpt2fa.py
+++ b/tests/crypto/test_arithmetic_gpt2fa.py
@@ -1,0 +1,87 @@
+"""Integration tests for arithmetic coding with Transformers-based LMs."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from neuralstego.crypto.arithmetic import decode_with_lm, encode_with_lm
+from neuralstego.crypto.distribution import TransformersLM
+
+
+class DummyGPT2Model:
+    """Synthetic language model producing deterministic logits."""
+
+    def __init__(self, vocab_size: int = 10) -> None:
+        self.vocab_size = vocab_size
+        self.device = torch.device("cpu")
+        self.config = SimpleNamespace(n_positions=32)
+
+    def to(self, device: torch.device | str | None = None, dtype: torch.dtype | None = None) -> "DummyGPT2Model":
+        if device is not None:
+            self.device = torch.device(device)
+        _ = dtype
+        return self
+
+    def eval(self) -> "DummyGPT2Model":
+        return self
+
+    def __call__(self, input_ids: torch.Tensor) -> SimpleNamespace:
+        if input_ids.ndim != 2:
+            raise ValueError("input_ids must be a 2-D tensor")
+        seq_len = input_ids.size(1)
+        logits = torch.zeros((1, seq_len, self.vocab_size), dtype=torch.float32, device=self.device)
+        context_score = float(input_ids.sum()) * 0.01
+        base = torch.linspace(0.0, 1.5, steps=self.vocab_size, device=self.device)
+        logits[0, -1] = base + context_score
+        return SimpleNamespace(logits=logits)
+
+
+def test_arithmetic_roundtrip_with_transformers_lm() -> None:
+    message = b"hidden payload"
+    context = [3, 7, 11]
+
+    lm = TransformersLM(model=DummyGPT2Model(vocab_size=12))
+    encode_state: dict[str, object] = {}
+    tokens = encode_with_lm(message, lm, context=context, state=encode_state)
+
+    assert tokens
+    assert "history" in encode_state
+
+    decode_state = dict(encode_state)
+    recovered = decode_with_lm(tokens, lm, context=context, state=decode_state)
+
+    assert recovered == message
+    assert decode_state.get("history") in (tuple(), None)
+
+
+def test_quality_constraints_reduce_capacity() -> None:
+    message = bytes(range(8))
+    context = [1, 2, 3]
+
+    baseline_lm = TransformersLM(model=DummyGPT2Model(vocab_size=16))
+    baseline_state: dict[str, object] = {}
+    baseline_tokens = encode_with_lm(message, baseline_lm, context=context, state=baseline_state)
+    assert baseline_tokens
+
+    constrained_lm = TransformersLM(model=DummyGPT2Model(vocab_size=16))
+    constrained_state: dict[str, object] = {}
+    constrained_tokens = encode_with_lm(
+        message,
+        constrained_lm,
+        context=context,
+        quality={"top_k": 2},
+        state=constrained_state,
+    )
+
+    assert constrained_tokens
+    baseline_history = np.array(baseline_state["history"], dtype=np.int32)
+    constrained_history = np.array(constrained_state["history"], dtype=np.int32)
+
+    avg_baseline = float(baseline_history.mean())
+    avg_constrained = float(constrained_history.mean())
+
+    assert avg_constrained <= avg_baseline + 1e-6

--- a/tests/crypto/test_distribution_transformers.py
+++ b/tests/crypto/test_distribution_transformers.py
@@ -1,0 +1,75 @@
+"""Tests for the Transformers-based language model adapter."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from neuralstego.crypto.distribution import TransformersLM
+
+
+class DummyGPT2Model:
+    """Minimal stand-in for ``GPT2LMHeadModel`` used in unit tests."""
+
+    def __init__(self, vocab_size: int = 8) -> None:
+        self.vocab_size = vocab_size
+        self.device = torch.device("cpu")
+        self.config = SimpleNamespace(n_positions=32)
+
+    def to(self, device: torch.device | str | None = None, dtype: torch.dtype | None = None) -> "DummyGPT2Model":
+        if device is not None:
+            self.device = torch.device(device)
+        _ = dtype
+        return self
+
+    def eval(self) -> "DummyGPT2Model":
+        return self
+
+    def __call__(self, input_ids: torch.Tensor) -> SimpleNamespace:
+        if input_ids.ndim != 2:
+            raise ValueError("input_ids must be a 2-D tensor")
+        seq_len = input_ids.size(1)
+        logits = torch.zeros((1, seq_len, self.vocab_size), dtype=torch.float32, device=self.device)
+        last_token = int(input_ids[0, -1])
+        base = torch.linspace(0.1, 1.0, steps=self.vocab_size, device=self.device)
+        logits[0, -1] = base + (last_token * 0.01)
+        return SimpleNamespace(logits=logits)
+
+
+def test_transformers_lm_normalises_probabilities() -> None:
+    model = DummyGPT2Model(vocab_size=6)
+    lm = TransformersLM(model=model)
+    probs = lm.next_token_probs([10, 20, 30])
+
+    assert isinstance(probs, np.ndarray)
+    assert probs.shape == (6,)
+    assert pytest.approx(1.0) == float(probs.sum())
+    assert probs.argmax() == 5  # highest logit after softmax
+
+
+def test_quality_policies_limit_distribution_support() -> None:
+    context = [1, 2, 3]
+
+    lm_topk = TransformersLM(model=DummyGPT2Model(vocab_size=8), top_k=2)
+    probs_topk = lm_topk.next_token_probs(context)
+    assert np.count_nonzero(probs_topk) == 2
+
+    lm_topp = TransformersLM(model=DummyGPT2Model(vocab_size=8), top_p=0.5)
+    probs_topp = lm_topp.next_token_probs(context)
+    assert pytest.approx(1.0) == float(probs_topp.sum())
+    assert np.count_nonzero(probs_topp) <= 4
+
+
+def test_temperature_adjustment_changes_distribution_shape() -> None:
+    context = [7, 8]
+    cold = TransformersLM(model=DummyGPT2Model(vocab_size=5), temperature=0.5)
+    warm = TransformersLM(model=DummyGPT2Model(vocab_size=5), temperature=1.5)
+
+    cold_probs = cold.next_token_probs(context)
+    warm_probs = warm.next_token_probs(context)
+
+    assert not np.allclose(cold_probs, warm_probs)
+    assert cold_probs.max() > warm_probs.max()


### PR DESCRIPTION
## Summary
- add a TransformersLM adapter backed by HooshvareLab/gpt2-fa with temperature and quality controls
- provide language-model-driven encode/decode helpers that apply quality policies and expose them from the crypto package
- cover the new integration with unit tests for the distribution adapter and arithmetic roundtrip behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e506878c2483328e1e4901ab59ec9d