### PR TITLE
Implement GPT2-fa quality controls and high-level API

### DIFF
--- a/src/neuralstego/crypto/__init__.py
+++ b/src/neuralstego/crypto/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from .aead import NONCE_SIZE, TAG_SIZE, aes_gcm_decrypt, aes_gcm_encrypt
-from .api import decrypt_message, encrypt_message
-from .arithmetic import decode_with_lm, encode_with_lm
+from .api import decode_text, decrypt_message, encode_text, encrypt_message
+from .arithmetic import decode_arithmetic, decode_with_lm, encode_arithmetic, encode_with_lm
 from .distribution import TransformersLM
 from .envelope import ENVELOPE_VERSION, pack_envelope, unpack_envelope
 from .errors import DecryptionError, EncryptionError, EnvelopeError, KDFError
@@ -26,10 +26,14 @@ __all__ = [
     "KDFMethod",
     "aes_gcm_decrypt",
     "aes_gcm_encrypt",
+    "decode_arithmetic",
+    "decode_text",
     "decrypt_message",
     "derive_key",
     "derive_key_argon2id",
     "derive_key_pbkdf2",
+    "encode_arithmetic",
+    "encode_text",
     "encrypt_message",
     "gen_salt",
     "pack_envelope",

--- a/src/neuralstego/crypto/arithmetic.py
+++ b/src/neuralstego/crypto/arithmetic.py
@@ -1,7 +1,112 @@
-"""Arithmetic coding helpers bound to language model providers."""
+"""Arithmetic coding helpers integrating crypto quality policies."""
 
 from __future__ import annotations
 
-from ..codec.arithmetic import decode_with_lm, encode_with_lm
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Sequence
 
-__all__ = ["encode_with_lm", "decode_with_lm"]
+from ..codec.arithmetic import decode_with_lm, encode_with_lm
+from ..codec.types import CodecState, LMProvider, ProbDist
+from .quality import apply_quality
+
+__all__ = [
+    "decode_with_lm",
+    "encode_with_lm",
+    "decode_arithmetic",
+    "encode_arithmetic",
+]
+
+
+@dataclass
+class _QualityControlledLM(LMProvider):
+    """Adapter applying quality policies to an underlying language model."""
+
+    base: LMProvider
+    top_k: int | None = None
+    top_p: float | None = None
+    temperature: float = 1.0
+
+    def next_token_probs(self, context_ids: Sequence[int]) -> ProbDist:  # noqa: D401
+        """Return filtered next-token probabilities for ``context_ids``."""
+
+        dist = self.base.next_token_probs(context_ids)
+        if self.top_k is None and self.top_p is None and self.temperature == 1.0:
+            return dist
+        return apply_quality(
+            dist,
+            top_k=self.top_k,
+            top_p=self.top_p,
+            temperature=self.temperature,
+        )
+
+
+def encode_arithmetic(
+    payload: bytes,
+    lm: LMProvider,
+    *,
+    quality: Mapping[str, object] | None = None,
+    seed_text: Sequence[int] | None = None,
+    state: MutableMapping[str, object] | None = None,
+) -> tuple[list[int], CodecState]:
+    """Encode ``payload`` bits using ``lm`` with the provided quality policies."""
+
+    policies = _extract_quality(quality)
+    controlled = _QualityControlledLM(lm, **policies)
+
+    encode_state: CodecState = {}
+    tokens = encode_with_lm(payload, controlled, context=tuple(seed_text or ()), state=encode_state)
+
+    if state is not None:
+        state.update(encode_state)
+
+    return tokens, encode_state
+
+
+def decode_arithmetic(
+    token_ids: Sequence[int],
+    lm: LMProvider,
+    *,
+    quality: Mapping[str, object] | None = None,
+    seed_text: Sequence[int] | None = None,
+    state: MutableMapping[str, object] | None = None,
+) -> bytes:
+    """Decode ``token_ids`` into the embedded payload bits."""
+
+    if state is None:
+        raise ValueError("state with bit consumption history is required for decoding")
+
+    policies = _extract_quality(quality)
+    controlled = _QualityControlledLM(lm, **policies)
+
+    decode_state: CodecState = {"history": tuple(), "residual_bits": b""}
+    decode_state.update(state)  # type: ignore[arg-type]
+
+    return decode_with_lm(
+        token_ids,
+        controlled,
+        context=tuple(seed_text or ()),
+        state=decode_state,
+    )
+
+
+def _extract_quality(quality: Mapping[str, object] | None) -> dict[str, object]:
+    if not quality:
+        return {"top_k": None, "top_p": None, "temperature": 1.0}
+
+    policies: dict[str, object] = {}
+    if "top_k" in quality:
+        policies["top_k"] = int(quality["top_k"]) if quality["top_k"] is not None else None
+    else:
+        policies["top_k"] = None
+
+    if "top_p" in quality:
+        policies["top_p"] = float(quality["top_p"]) if quality["top_p"] is not None else None
+    else:
+        policies["top_p"] = None
+
+    if "temperature" in quality:
+        policies["temperature"] = float(quality["temperature"])
+    else:
+        policies["temperature"] = 1.0
+
+    return policies

--- a/src/neuralstego/crypto/quality.py
+++ b/src/neuralstego/crypto/quality.py
@@ -1,0 +1,127 @@
+"""Quality-control helpers for GPT2-fa steganographic pipelines."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from ..codec.errors import QualityConfigError
+from ..codec.types import ProbDist
+
+__all__ = ["apply_quality"]
+
+
+def apply_quality(
+    dist: ProbDist,
+    *,
+    top_k: int | None = None,
+    top_p: float | None = None,
+    temperature: float = 1.0,
+) -> ProbDist:
+    """Apply quality constraints to a language-model distribution.
+
+    Parameters
+    ----------
+    dist:
+        Probability distribution emitted by the base language model.
+    top_k:
+        Retain only the *k* most-likely tokens when provided.
+    top_p:
+        Retain the smallest prefix whose cumulative probability exceeds the
+        specified threshold (also known as nucleus sampling).
+    temperature:
+        Soften or sharpen the distribution prior to filtering.  Values below
+        ``1.0`` make the distribution more peaky while values above ``1.0``
+        increase diversity.  The parameter must be strictly positive.
+
+    Returns
+    -------
+    ProbDist
+        A filtered and re-normalised distribution matching the input type.
+
+    Raises
+    ------
+    QualityConfigError
+        If the supplied parameters would eliminate all probability mass or if
+        they violate their respective domains.
+    """
+
+    if temperature <= 0.0:
+        raise QualityConfigError("temperature must be positive")
+
+    tokens, probs = _dist_to_arrays(dist)
+    probs = _normalise(probs)
+
+    if not math.isclose(temperature, 1.0):
+        logits = np.log(probs + 1e-12)
+        scaled = logits / float(temperature)
+        scaled -= float(np.max(scaled))
+        probs = np.exp(scaled)
+        probs = _normalise(probs)
+
+    mask = np.ones_like(probs, dtype=bool)
+
+    if top_k is not None:
+        if top_k <= 0:
+            raise QualityConfigError("top_k must be positive")
+        order = np.argsort(probs)[::-1]
+        keep = order[: min(top_k, probs.size)]
+        mask = np.zeros_like(mask)
+        mask[keep] = True
+
+    if top_p is not None:
+        if not 0.0 < top_p <= 1.0:
+            raise QualityConfigError("top_p must lie within (0, 1]")
+        order = np.argsort(probs)[::-1]
+        cumulative = np.cumsum(probs[order])
+        cutoff = np.searchsorted(cumulative, top_p, side="left")
+        nucleus = order[: cutoff + 1]
+        nucleus_mask = np.zeros_like(mask)
+        nucleus_mask[nucleus] = True
+        mask &= nucleus_mask
+
+    filtered = np.where(mask, probs, 0.0)
+    if not np.any(filtered):
+        raise QualityConfigError("Quality constraints removed all probability mass")
+
+    filtered = _normalise(filtered)
+    return _arrays_to_dist(tokens, filtered, dist)
+
+
+def _dist_to_arrays(dist: ProbDist) -> tuple[np.ndarray, np.ndarray]:
+    if isinstance(dist, np.ndarray):
+        probs = dist.astype(np.float64, copy=True)
+        tokens = np.arange(probs.size, dtype=np.int64)
+        return tokens, probs
+    if isinstance(dist, dict):
+        items = sorted(dist.items())
+        tokens = np.array([int(token) for token, _ in items], dtype=np.int64)
+        probs = np.array([float(prob) for _, prob in items], dtype=np.float64)
+        return tokens, probs
+    raise TypeError(f"Unsupported distribution type: {type(dist)!r}")
+
+
+def _arrays_to_dist(
+    tokens: np.ndarray,
+    probs: np.ndarray,
+    original: ProbDist,
+) -> ProbDist:
+    if isinstance(original, np.ndarray):
+        result = np.zeros_like(original, dtype=np.float64)
+        result[tokens] = probs
+        return result
+    mapping = {
+        int(token): float(prob)
+        for token, prob in zip(tokens.tolist(), probs.tolist())
+        if prob > 0.0
+    }
+    return mapping
+
+
+def _normalise(values: np.ndarray) -> np.ndarray:
+    total = float(values.sum())
+    if not math.isfinite(total) or total <= 0.0:
+        raise QualityConfigError("Probability mass vanished during normalisation")
+    return values / total
+

--- a/tests/crypto/test_api_gpt2fa.py
+++ b/tests/crypto/test_api_gpt2fa.py
@@ -1,0 +1,48 @@
+"""High-level API tests for GPT2-fa steganographic encoding."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from neuralstego.codec.distribution import MockLM
+from neuralstego.crypto import api
+
+
+def test_encode_decode_roundtrip_with_custom_lm() -> None:
+    message = "پیام مخفی"
+    password = "hunter2"
+    seed_text = "سلام دنیا"
+    lm = MockLM(vocab_size=64)
+
+    quality = {"lm": lm, "top_k": 8, "temperature": 0.9}
+
+    blob = api.encode_text(message, password, quality=quality, seed_text=seed_text)
+    recovered = api.decode_text(blob, password, quality=quality, seed_text=seed_text)
+
+    assert isinstance(blob, bytes)
+    assert recovered == message
+
+
+def test_fallback_to_mock_language_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _broken_transformers(*args: object, **kwargs: object) -> object:
+        raise OSError("model unavailable")
+
+    monkeypatch.setattr(api, "TransformersLM", _broken_transformers)
+
+    message = "secret"
+    password = "password123"
+
+    blob = api.encode_text(message, password, quality={}, seed_text="")
+    recovered = api.decode_text(blob, password, quality={}, seed_text="")
+
+    assert recovered == message
+
+
+def test_decode_with_wrong_seed_raises() -> None:
+    quality = {"lm": MockLM(vocab_size=32)}
+    blob = api.encode_text("hidden", "pw", quality=quality, seed_text="seed")
+
+    with pytest.raises(ValueError):
+        api.decode_text(blob, "pw", quality=quality, seed_text="different")

--- a/tests/crypto/test_quality_gpt2fa.py
+++ b/tests/crypto/test_quality_gpt2fa.py
@@ -1,0 +1,59 @@
+"""Tests for quality policies applied to GPT2-fa style distributions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("cryptography")
+
+from neuralstego.codec.errors import QualityConfigError
+from neuralstego.crypto.quality import apply_quality
+
+
+def _entropy(probs: np.ndarray) -> float:
+    mask = probs > 0.0
+    values = probs[mask]
+    return float(-(values * np.log2(values)).sum())
+
+
+def test_apply_quality_with_top_k_restricts_support() -> None:
+    probs = np.array([0.4, 0.3, 0.2, 0.1], dtype=np.float64)
+    filtered = apply_quality(probs, top_k=2)
+
+    assert filtered.sum() == pytest.approx(1.0)
+    assert np.count_nonzero(filtered) == 2
+
+
+def test_apply_quality_with_top_p_limits_mass() -> None:
+    probs = np.array([0.5, 0.2, 0.15, 0.1, 0.05], dtype=np.float64)
+    filtered = apply_quality(probs, top_p=0.7)
+
+    # The filtered distribution should only contain the minimal set of tokens
+    # whose mass exceeds the nucleus threshold.
+    order = np.argsort(probs)[::-1]
+    cumulative = np.cumsum(probs[order])
+    cutoff = np.searchsorted(cumulative, 0.7, side="left")
+    expected_support = set(order[: cutoff + 1])
+    actual_support = {index for index, value in enumerate(filtered) if value > 0.0}
+
+    assert actual_support == expected_support
+
+
+def test_temperature_controls_entropy() -> None:
+    probs = np.array([0.05, 0.2, 0.25, 0.3, 0.2], dtype=np.float64)
+
+    cold = apply_quality(probs, temperature=0.5)
+    warm = apply_quality(probs, temperature=1.5)
+
+    assert _entropy(cold) < _entropy(warm)
+
+
+def test_invalid_configuration_raises() -> None:
+    probs = np.array([0.6, 0.4], dtype=np.float64)
+
+    with pytest.raises(QualityConfigError):
+        apply_quality(probs, top_k=0)
+
+    with pytest.raises(QualityConfigError):
+        apply_quality(probs, temperature=0.0)


### PR DESCRIPTION
## Summary
- add a crypto quality module that applies temperature, top-k, and top-p filtering directly to model distributions
- extend the crypto arithmetic helpers to wrap language models with the new quality policies and expose encode/decode utilities
- implement high-level encode_text/decode_text APIs with fallback MockLM support and add dedicated GPT2-fa tests

## Testing
- `pytest tests/crypto/test_quality_gpt2fa.py tests/crypto/test_api_gpt2fa.py` *(skipped: cryptography dependency unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68e50b7f12688332af7653171a3896ec