### PR TITLE
Add framing utilities with CRC and Reed-Solomon support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ transformers==4.52.4
 triton==3.3.1
 typing_extensions==4.14.0
 urllib3==2.4.0
+reedsolo==1.7.0

--- a/src/neuralstego/__init__.py
+++ b/src/neuralstego/__init__.py
@@ -1,0 +1,2 @@
+"""Neural steganography helpers."""
+

--- a/src/neuralstego/framing/__init__.py
+++ b/src/neuralstego/framing/__init__.py
@@ -1,0 +1,36 @@
+"""Framing utilities for steganographic payload packets."""
+
+from .errors import (
+    FramingError,
+    PacketValidationError,
+    PacketVersionError,
+    PacketIntegrityError,
+    PacketConsistencyError,
+    NotAvailableError,
+)
+from .packet import PacketCfg, ECCCfg, ParsedPacket, build_packet, parse_packet
+from .crc import crc32, append_crc32, verify_crc32
+from .ecc import rs_encode, rs_decode
+from .chunker import chunk_payload, reassemble_packets
+
+__all__ = [
+    "FramingError",
+    "PacketValidationError",
+    "PacketVersionError",
+    "PacketIntegrityError",
+    "PacketConsistencyError",
+    "NotAvailableError",
+    "PacketCfg",
+    "ECCCfg",
+    "ParsedPacket",
+    "build_packet",
+    "parse_packet",
+    "crc32",
+    "append_crc32",
+    "verify_crc32",
+    "rs_encode",
+    "rs_decode",
+    "chunk_payload",
+    "reassemble_packets",
+]
+

--- a/src/neuralstego/framing/chunker.py
+++ b/src/neuralstego/framing/chunker.py
@@ -1,0 +1,118 @@
+"""Helpers for chunking payloads into packets and reassembling them."""
+
+from __future__ import annotations
+
+import uuid
+from typing import List, Optional, Sequence, Tuple
+
+from .crc import append_crc32, verify_crc32
+from .ecc import rs_decode, rs_encode
+from .errors import PacketConsistencyError, PacketIntegrityError, PacketValidationError
+from .packet import PacketCfg, ParsedPacket, build_packet, parse_packet
+
+
+def _normalise_payload(payload: bytes) -> bytes:
+    if isinstance(payload, (bytes, bytearray)):
+        return bytes(payload)
+    raise PacketValidationError("payload must be bytes")
+
+
+def _apply_ecc(cfg: PacketCfg, data: bytes) -> bytes:
+    if not cfg.ecc.enabled:
+        return data
+    if cfg.ecc.name != "rs":
+        raise PacketValidationError(f"Unsupported ECC codec: {cfg.ecc.name}")
+    nsym = cfg.ecc.nsym or 10
+    return rs_encode(data, nsym=nsym)
+
+
+def _remove_ecc(cfg: PacketCfg, data: bytes) -> Tuple[bool, bytes]:
+    if not cfg.ecc.enabled:
+        return True, data
+    if cfg.ecc.name != "rs":
+        raise PacketValidationError(f"Unsupported ECC codec: {cfg.ecc.name}")
+    nsym = cfg.ecc.nsym or 10
+    return rs_decode(data, nsym=nsym)
+
+
+def chunk_payload(
+    payload: bytes,
+    *,
+    chunk_size: int,
+    cfg: PacketCfg,
+    meta: Optional[dict] = None,
+    msg_id: Optional[str] = None,
+    store_plain: bool = False,
+) -> List[bytes]:
+    """Split *payload* into framed packet blobs."""
+
+    if chunk_size <= 0:
+        raise PacketValidationError("chunk_size must be positive")
+    payload = _normalise_payload(payload)
+    msg_uuid = msg_id or str(uuid.uuid4())
+
+    chunks = [payload[i : i + chunk_size] for i in range(0, len(payload), chunk_size)]
+    if not chunks:
+        chunks = [b""]
+    total = len(chunks)
+
+    packets: List[bytes] = []
+    for seq, chunk in enumerate(chunks):
+        plain_chunk = bytes(chunk)
+        processed = plain_chunk
+        if cfg.crc_enabled:
+            processed = append_crc32(processed)
+        processed = _apply_ecc(cfg, processed)
+        packet = build_packet(
+            processed,
+            seq=seq,
+            total=total,
+            msg_id=msg_uuid,
+            cfg=cfg,
+            meta=meta,
+            plain_payload=plain_chunk if store_plain else None,
+        )
+        packets.append(packet)
+    return packets
+
+
+def reassemble_packets(blobs: Sequence[bytes]) -> Tuple[bytes, PacketCfg, Optional[dict], str]:
+    """Reconstruct the original payload from a sequence of packet blobs."""
+
+    if not blobs:
+        raise PacketValidationError("No packets supplied")
+
+    packets: List[ParsedPacket] = [parse_packet(blob) for blob in blobs]
+    packets.sort(key=lambda pkt: pkt.seq)
+
+    first = packets[0]
+    total = first.total
+    if len(packets) != total:
+        raise PacketConsistencyError("Missing packets for reconstruction")
+
+    for idx, pkt in enumerate(packets):
+        if pkt.seq != idx:
+            raise PacketConsistencyError("Packet sequence numbers are not contiguous")
+        if pkt.total != total:
+            raise PacketConsistencyError("Packet totals differ")
+        if pkt.msg_id != first.msg_id:
+            raise PacketConsistencyError("Packets belong to different messages")
+        if pkt.cfg != first.cfg:
+            raise PacketConsistencyError("Packet configurations differ")
+        if pkt.meta != first.meta:
+            raise PacketConsistencyError("Packet metadata differs")
+
+    cfg = first.cfg
+    recovered: List[bytes] = []
+    for pkt in packets:
+        data = pkt.payload
+        ok, data = _remove_ecc(cfg, data)
+        if not ok:
+            raise PacketIntegrityError("ECC decoding failed")
+        if cfg.crc_enabled:
+            ok, data = verify_crc32(data)
+            if not ok:
+                raise PacketIntegrityError("CRC mismatch detected")
+        recovered.append(data)
+
+    return b"".join(recovered), cfg, first.meta, first.msg_id

--- a/src/neuralstego/framing/crc.py
+++ b/src/neuralstego/framing/crc.py
@@ -1,0 +1,45 @@
+"""CRC helper functions."""
+
+from __future__ import annotations
+
+import struct
+import zlib
+
+CRC32_POLY = 0xEDB88320
+CRC32_INITIAL = 0
+
+
+def crc32(data: bytes) -> int:
+    """Compute the CRC32 checksum of *data*.
+
+    The checksum uses the same polynomial as :func:`zlib.crc32` and returns an
+    unsigned 32-bit integer.
+    """
+
+    return zlib.crc32(data, CRC32_INITIAL) & 0xFFFFFFFF
+
+
+def append_crc32(payload: bytes) -> bytes:
+    """Return ``payload`` concatenated with a big-endian CRC32."""
+
+    checksum = crc32(payload)
+    return payload + struct.pack(">I", checksum)
+
+
+def verify_crc32(blob: bytes) -> tuple[bool, bytes]:
+    """Verify the CRC32 appended to *blob*.
+
+    Returns a tuple ``(ok, payload_without_crc)``.  ``ok`` is ``True`` when the
+    checksum matches, ``False`` otherwise.  The payload is returned without the
+    trailing 4-byte checksum regardless of the outcome.  When *blob* is shorter
+    than four bytes, the function treats the checksum as missing and returns
+    ``False`` together with the unchanged data.
+    """
+
+    if len(blob) < 4:
+        return False, blob
+
+    payload, checksum_bytes = blob[:-4], blob[-4:]
+    expected = struct.unpack(">I", checksum_bytes)[0]
+    actual = crc32(payload)
+    return actual == expected, payload

--- a/src/neuralstego/framing/ecc.py
+++ b/src/neuralstego/framing/ecc.py
@@ -1,0 +1,51 @@
+"""Reed-Solomon error correction helpers."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from .errors import NotAvailableError
+
+try:  # pragma: no cover - import guard
+    import reedsolo
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    reedsolo = None
+
+
+def _require_reedsolo() -> "reedsolo":
+    if reedsolo is None:
+        raise NotAvailableError(
+            "reedsolo is not installed. Install the 'reedsolo' package to enable ECC support."
+        )
+    return reedsolo
+
+
+def rs_encode(data: bytes, nsym: int = 10) -> bytes:
+    """Encode *data* with Reed-Solomon error correction."""
+
+    rs = _require_reedsolo().RSCodec(nsym)
+    return bytes(rs.encode(bytearray(data)))
+
+
+def rs_decode(codeword: bytes, nsym: int = 10) -> Tuple[bool, bytes]:
+    """Decode a Reed-Solomon codeword.
+
+    Returns ``(ok, data)`` where ``ok`` is ``True`` when decoding was successful
+    and ``False`` otherwise.  When decoding fails the data component is an empty
+    byte-string.
+    """
+
+    rs_module = _require_reedsolo()
+    codec = rs_module.RSCodec(nsym)
+    try:
+        decoded = codec.decode(bytearray(codeword))
+    except rs_module.ReedSolomonError:
+        return False, b""
+
+    if isinstance(decoded, tuple):
+        data = decoded[0]
+    else:
+        data = decoded
+    if isinstance(data, bytearray):
+        data = bytes(data)
+    return True, data

--- a/src/neuralstego/framing/errors.py
+++ b/src/neuralstego/framing/errors.py
@@ -1,0 +1,27 @@
+"""Exception types for the framing subsystem."""
+
+from __future__ import annotations
+
+
+class FramingError(RuntimeError):
+    """Base class for framing related errors."""
+
+
+class PacketValidationError(FramingError):
+    """Raised when a packet fails schema validation."""
+
+
+class PacketVersionError(PacketValidationError):
+    """Raised when the packet version is unsupported."""
+
+
+class PacketIntegrityError(PacketValidationError):
+    """Raised when integrity checks fail (CRC/ECC)."""
+
+
+class PacketConsistencyError(PacketValidationError):
+    """Raised when packets of the same message disagree on metadata."""
+
+
+class NotAvailableError(FramingError):
+    """Raised when an optional dependency is unavailable."""

--- a/src/neuralstego/framing/packet.py
+++ b/src/neuralstego/framing/packet.py
@@ -1,0 +1,210 @@
+"""Packet building and parsing utilities."""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from .errors import PacketValidationError, PacketVersionError
+
+SUPPORTED_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ECCCfg:
+    """Configuration for optional ECC processing."""
+
+    name: str = "none"
+    nsym: Optional[int] = None
+
+    def to_dict(self) -> Optional[Dict[str, Any]]:
+        if self.name == "none":
+            return None
+        data: Dict[str, Any] = {"name": self.name}
+        if self.nsym is not None:
+            data["nsym"] = self.nsym
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "ECCCfg":
+        if not data:
+            return cls()
+        if not isinstance(data, dict):
+            raise PacketValidationError("'ecc' must be an object when provided")
+        name = data.get("name", "none")
+        nsym = data.get("nsym")
+        if nsym is not None and (not isinstance(nsym, int) or nsym <= 0):
+            raise PacketValidationError("'ecc.nsym' must be a positive integer")
+        return cls(name=name, nsym=nsym)
+
+    @property
+    def enabled(self) -> bool:
+        return self.name != "none"
+
+
+@dataclass(frozen=True)
+class PacketCfg:
+    """Packet level integrity configuration."""
+
+    crc: str = "none"
+    ecc: ECCCfg = field(default_factory=ECCCfg)
+
+    def __post_init__(self) -> None:  # pragma: no cover - dataclass hook
+        object.__setattr__(self, "ecc", self.ecc if isinstance(self.ecc, ECCCfg) else ECCCfg.from_dict(self.ecc))
+        if self.crc not in {"none", "crc32"}:
+            raise PacketValidationError("Unsupported CRC mode")
+        if not isinstance(self.ecc, ECCCfg):
+            raise PacketValidationError("Invalid ECC configuration")
+
+    def to_dict(self) -> Dict[str, Any]:
+        cfg: Dict[str, Any] = {"crc": self.crc}
+        ecc_dict = self.ecc.to_dict()
+        if ecc_dict is not None:
+            cfg["ecc"] = ecc_dict
+        return cfg
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PacketCfg":
+        if not isinstance(data, dict):
+            raise PacketValidationError("'cfg' must be an object")
+        crc = data.get("crc", "none")
+        ecc = ECCCfg.from_dict(data.get("ecc"))
+        return cls(crc=crc, ecc=ecc)
+
+    @property
+    def crc_enabled(self) -> bool:
+        return self.crc == "crc32"
+
+
+@dataclass(frozen=True)
+class ParsedPacket:
+    """Representation of a parsed packet."""
+
+    version: int
+    msg_id: str
+    seq: int
+    total: int
+    cfg: PacketCfg
+    meta: Optional[Dict[str, Any]]
+    payload: bytes
+    plain_payload: Optional[bytes]
+
+
+def _ensure_uuid(msg_id: str) -> str:
+    try:
+        uuid.UUID(msg_id)
+    except (ValueError, AttributeError):
+        raise PacketValidationError("'id' must be a valid UUID string") from None
+    return msg_id
+
+
+def build_packet(
+    payload: bytes,
+    *,
+    seq: int,
+    total: int,
+    msg_id: str,
+    cfg: PacketCfg,
+    meta: Optional[Dict[str, Any]] = None,
+    plain_payload: Optional[bytes] = None,
+) -> bytes:
+    """Build a serialised packet blob."""
+
+    if not isinstance(payload, (bytes, bytearray)):
+        raise PacketValidationError("payload must be bytes")
+    if seq < 0:
+        raise PacketValidationError("'seq' must be non-negative")
+    if total <= 0 or seq >= total:
+        raise PacketValidationError("'total' must be positive and seq < total")
+    if not isinstance(msg_id, str):
+        raise PacketValidationError("'id' must be a string")
+
+    msg_id = _ensure_uuid(msg_id)
+    cfg_dict = cfg.to_dict()
+
+    packet: Dict[str, Any] = {
+        "v": SUPPORTED_VERSION,
+        "id": msg_id,
+        "seq": seq,
+        "total": total,
+        "cfg": cfg_dict,
+    }
+    if meta is not None:
+        if not isinstance(meta, dict):
+            raise PacketValidationError("'meta' must be a mapping when provided")
+        packet["meta"] = meta
+    if plain_payload is not None:
+        packet["pt"] = base64.b64encode(bytes(plain_payload)).decode("ascii")
+    packet["ct"] = base64.b64encode(bytes(payload)).decode("ascii")
+
+    return json.dumps(packet, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def parse_packet(blob: bytes) -> ParsedPacket:
+    """Parse a packet created by :func:`build_packet`."""
+
+    if not isinstance(blob, (bytes, bytearray)):
+        raise PacketValidationError("Packet blob must be bytes")
+
+    try:
+        data = json.loads(bytes(blob).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
+        raise PacketValidationError("Invalid packet encoding") from exc
+
+    if not isinstance(data, dict):
+        raise PacketValidationError("Packet must decode to an object")
+
+    version = data.get("v")
+    if version != SUPPORTED_VERSION:
+        raise PacketVersionError(f"Unsupported packet version: {version!r}")
+
+    msg_id = data.get("id")
+    seq = data.get("seq")
+    total = data.get("total")
+    cfg_dict = data.get("cfg")
+    meta = data.get("meta") if "meta" in data else None
+
+    if not isinstance(seq, int) or seq < 0:
+        raise PacketValidationError("'seq' must be a non-negative integer")
+    if not isinstance(total, int) or total <= 0 or seq >= total:
+        raise PacketValidationError("'total' must be a positive integer with seq < total")
+    if not isinstance(msg_id, str):
+        raise PacketValidationError("'id' must be a string")
+    msg_id = _ensure_uuid(msg_id)
+
+    cfg = PacketCfg.from_dict(cfg_dict)
+
+    payload_b64 = data.get("ct")
+    if not isinstance(payload_b64, str):
+        raise PacketValidationError("'ct' must be a base64 string")
+    try:
+        payload = base64.b64decode(payload_b64, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise PacketValidationError("'ct' is not valid base64") from exc
+
+    plain_payload_b64 = data.get("pt")
+    plain_payload = None
+    if plain_payload_b64 is not None:
+        if not isinstance(plain_payload_b64, str):
+            raise PacketValidationError("'pt' must be a base64 string")
+        try:
+            plain_payload = base64.b64decode(plain_payload_b64, validate=True)
+        except (ValueError, TypeError) as exc:
+            raise PacketValidationError("'pt' is not valid base64") from exc
+
+    if meta is not None and not isinstance(meta, dict):
+        raise PacketValidationError("'meta' must be an object when provided")
+
+    return ParsedPacket(
+        version=version,
+        msg_id=msg_id,
+        seq=seq,
+        total=total,
+        cfg=cfg,
+        meta=meta,
+        payload=payload,
+        plain_payload=plain_payload,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if SRC.exists():
+    sys.path.insert(0, str(SRC))

--- a/tests/framing/test_chunker.py
+++ b/tests/framing/test_chunker.py
@@ -1,0 +1,74 @@
+import base64
+import json
+import uuid
+
+import pytest
+
+from neuralstego.framing import (
+    ECCCfg,
+    PacketCfg,
+    PacketConsistencyError,
+    PacketIntegrityError,
+    chunk_payload,
+    reassemble_packets,
+)
+from neuralstego.framing.errors import NotAvailableError
+
+
+def _corrupt_packet(blob: bytes, *, flip_positions: list[int]) -> bytes:
+    data = json.loads(blob.decode("utf-8"))
+    ct = bytearray(base64.b64decode(data["ct"]))
+    for pos in flip_positions:
+        ct[pos] ^= 0xFF
+    data["ct"] = base64.b64encode(bytes(ct)).decode("ascii")
+    return json.dumps(data, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def test_chunker_roundtrip_crc_only():
+    cfg = PacketCfg(crc="crc32")
+    payload = bytes(range(100))
+    meta = {"mime": "application/octet-stream"}
+
+    packets = chunk_payload(payload, chunk_size=16, cfg=cfg, meta=meta, store_plain=True)
+    assert len(packets) == (len(payload) + 15) // 16
+
+    recovered, recovered_cfg, recovered_meta, msg_id = reassemble_packets(packets)
+    assert recovered == payload
+    assert recovered_cfg == cfg
+    assert recovered_meta == meta
+    uuid.UUID(msg_id)  # Should not raise.
+
+    with pytest.raises(PacketConsistencyError):
+        reassemble_packets(packets[:-1])
+
+
+def test_chunker_with_ecc_recovers_corruption():
+    cfg = PacketCfg(crc="crc32", ecc=ECCCfg(name="rs", nsym=8))
+    payload = b"error correction demo payload"
+
+    try:
+        packets = chunk_payload(payload, chunk_size=10, cfg=cfg, store_plain=False)
+    except NotAvailableError:
+        pytest.skip("reedsolo not installed")
+
+    corrupted = list(packets)
+    corrupted[0] = _corrupt_packet(corrupted[0], flip_positions=[0, 1])
+
+    recovered, _, _, _ = reassemble_packets(corrupted)
+    assert recovered == payload
+
+
+def test_chunker_detects_unrecoverable_corruption():
+    cfg = PacketCfg(crc="crc32", ecc=ECCCfg(name="rs", nsym=4))
+    payload = b"short"
+
+    try:
+        packets = chunk_payload(payload, chunk_size=5, cfg=cfg, store_plain=False)
+    except NotAvailableError:
+        pytest.skip("reedsolo not installed")
+
+    corrupted = list(packets)
+    corrupted[0] = _corrupt_packet(corrupted[0], flip_positions=[0, 1, 2])
+
+    with pytest.raises(PacketIntegrityError):
+        reassemble_packets(corrupted)

--- a/tests/framing/test_crc.py
+++ b/tests/framing/test_crc.py
@@ -1,0 +1,20 @@
+from neuralstego.framing.crc import append_crc32, crc32, verify_crc32
+
+
+def test_crc32_known_value():
+    payload = b"hello"
+    assert crc32(payload) == 0x3610A686
+
+
+def test_crc_roundtrip_and_detection():
+    payload = b"payload"
+    blob = append_crc32(payload)
+    ok, recovered = verify_crc32(blob)
+    assert ok
+    assert recovered == payload
+
+    corrupted = bytearray(blob)
+    corrupted[0] ^= 0xFF
+    ok, recovered = verify_crc32(bytes(corrupted))
+    assert not ok
+    assert recovered != payload

--- a/tests/framing/test_ecc.py
+++ b/tests/framing/test_ecc.py
@@ -1,0 +1,48 @@
+import pytest
+
+from neuralstego.framing import NotAvailableError, rs_decode, rs_encode
+
+
+def test_rs_roundtrip():
+    data = b"neural stego"
+    try:
+        encoded = rs_encode(data, nsym=8)
+    except NotAvailableError:
+        pytest.skip("reedsolo not installed")
+    ok, decoded = rs_decode(encoded, nsym=8)
+    assert ok
+    assert decoded == data
+
+
+def test_rs_corrects_errors():
+    data = b"0123456789abcdef"
+    try:
+        encoded = bytearray(rs_encode(data, nsym=8))
+    except NotAvailableError:
+        pytest.skip("reedsolo not installed")
+
+    # Corrupt up to nsym/2 bytes (here 4)
+    encoded[0] ^= 0x01
+    encoded[3] ^= 0x01
+    encoded[5] ^= 0x02
+
+    ok, decoded = rs_decode(bytes(encoded), nsym=8)
+    assert ok
+    assert decoded == data
+
+
+def test_rs_failure_on_excess_errors():
+    data = b"another block"
+    try:
+        encoded = bytearray(rs_encode(data, nsym=4))
+    except NotAvailableError:
+        pytest.skip("reedsolo not installed")
+
+    # Corrupt more than nsym/2 (=2) bytes.
+    encoded[0] ^= 0x01
+    encoded[1] ^= 0x02
+    encoded[2] ^= 0x04
+
+    ok, decoded = rs_decode(bytes(encoded), nsym=4)
+    assert not ok
+    assert decoded == b""

--- a/tests/framing/test_packet.py
+++ b/tests/framing/test_packet.py
@@ -1,0 +1,44 @@
+import uuid
+
+import pytest
+
+from neuralstego.framing.packet import ECCCfg, PacketCfg, build_packet, parse_packet
+from neuralstego.framing.errors import PacketValidationError
+
+
+def test_packet_roundtrip():
+    payload = b"hello world"
+    msg_id = str(uuid.uuid4())
+    cfg = PacketCfg(crc="crc32", ecc=ECCCfg(name="rs", nsym=10))
+    meta = {"mime": "text/plain", "note": "demo"}
+
+    blob = build_packet(
+        payload,
+        seq=0,
+        total=1,
+        msg_id=msg_id,
+        cfg=cfg,
+        meta=meta,
+        plain_payload=payload,
+    )
+
+    parsed = parse_packet(blob)
+    assert parsed.msg_id == msg_id
+    assert parsed.seq == 0
+    assert parsed.total == 1
+    assert parsed.payload == payload
+    assert parsed.plain_payload == payload
+    assert parsed.cfg == cfg
+    assert parsed.meta == meta
+
+
+def test_packet_validation_errors():
+    cfg = PacketCfg()
+    msg_id = str(uuid.uuid4())
+
+    with pytest.raises(PacketValidationError):
+        build_packet(b"data", seq=-1, total=1, msg_id=msg_id, cfg=cfg)
+
+    with pytest.raises(PacketValidationError):
+        blob = build_packet(b"data", seq=0, total=1, msg_id=msg_id, cfg=cfg)
+        parse_packet(blob + b"garbage")


### PR DESCRIPTION
## Summary
- add a framing package for building and parsing stego packets with versioned metadata
- implement CRC32 helpers, Reed-Solomon ECC wrappers, and payload chunking/reassembly utilities
- cover the new functionality with pytest suites and configure the test path hook

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e61ec60df88332bcc1f400fb52954a