### PR TITLE
Add metric computation and detection guard scaffolding

### DIFF
--- a/src/neuralstego/detect/__init__.py
+++ b/src/neuralstego/detect/__init__.py
@@ -1,0 +1,13 @@
+"""Detection utilities for assessing cover text quality."""
+
+from .features import EXPECTED_FEATURES, extract_features
+from .guard import GuardResult, QualityGuard
+from .classifier import DetectionClassifier
+
+__all__ = [
+    "EXPECTED_FEATURES",
+    "DetectionClassifier",
+    "GuardResult",
+    "QualityGuard",
+    "extract_features",
+]

--- a/src/neuralstego/detect/classifier.py
+++ b/src/neuralstego/detect/classifier.py
@@ -1,0 +1,50 @@
+"""Optional logistic-regression based detector wrapper."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import pickle
+from dataclasses import dataclass
+from typing import List, Sequence
+
+from .features import EXPECTED_FEATURES
+
+
+@dataclass
+class DetectionClassifier:
+    """Wrap a scikit-learn logistic regression model for suspiciousness scoring."""
+
+    model: object | None = None
+    feature_order: Sequence[str] = EXPECTED_FEATURES
+
+    def _require_sklearn(self) -> object:
+        if importlib.util.find_spec("sklearn") is None:
+            raise RuntimeError("scikit-learn is required for DetectionClassifier but is not installed")
+        return importlib.import_module("sklearn.linear_model")
+
+    def train(self, X: Sequence[Sequence[float]], y: Sequence[int]) -> bytes:
+        """Fit a logistic regression model and return a serialized representation."""
+
+        linear_model = self._require_sklearn()
+        classifier = linear_model.LogisticRegression(max_iter=1000)
+        classifier.fit(X, y)
+        self.model = classifier
+        return pickle.dumps(classifier)
+
+    def load(self, payload: bytes) -> None:
+        """Load a serialized logistic regression model."""
+
+        self.model = pickle.loads(payload)
+
+    def _vectorize(self, features: dict[str, float]) -> List[float]:
+        return [float(features.get(name, 0.0)) for name in self.feature_order]
+
+    def predict_proba(self, features: dict[str, float]) -> float:
+        """Return the suspiciousness probability for the provided feature mapping."""
+
+        if self.model is None:
+            raise RuntimeError("No model has been trained or loaded for DetectionClassifier")
+        probabilities = self.model.predict_proba([self._vectorize(features)])
+        # We assume label 1 corresponds to "suspicious".
+        return float(probabilities[0][1])

--- a/src/neuralstego/detect/features.py
+++ b/src/neuralstego/detect/features.py
@@ -1,0 +1,20 @@
+"""Feature extraction utilities for the detection guard."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+EXPECTED_FEATURES = (
+    "ppl",
+    "avg_nll",
+    "avg_entropy",
+    "ngram_repeat_ratio",
+    "type_token_ratio",
+    "avg_sentence_len",
+)
+
+
+def extract_features(metrics: Dict[str, float]) -> Dict[str, float]:
+    """Extract a consistent feature mapping from collected metrics."""
+
+    return {name: float(metrics.get(name, 0.0)) for name in EXPECTED_FEATURES}

--- a/src/neuralstego/detect/guard.py
+++ b/src/neuralstego/detect/guard.py
@@ -1,0 +1,86 @@
+"""Rule-based guard that decides whether a cover text passes quality thresholds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from ..metrics import (
+    LMScorer,
+    avg_entropy,
+    avg_sentence_len,
+    ngram_repeat_ratio,
+    type_token_ratio,
+)
+from .features import extract_features
+
+
+@dataclass
+class GuardResult:
+    """Structured response returned by :class:`QualityGuard`."""
+
+    passed: bool
+    reasons: List[str]
+    metrics: Dict[str, float]
+    detector_score: Optional[float] = None
+
+
+@dataclass
+class QualityGuard:
+    """Evaluate cover text quality using heuristic thresholds and optional models."""
+
+    lm_scorer: LMScorer = field(default_factory=LMScorer)
+    classifier: Optional[object] = None
+
+    def _collect_metrics(self, text: str) -> Dict[str, float]:
+        lm_metrics = self.lm_scorer.score(text)
+        stats = {
+            "ngram_repeat_ratio": ngram_repeat_ratio(text),
+            "type_token_ratio": type_token_ratio(text),
+            "avg_sentence_len": avg_sentence_len(text),
+            "avg_entropy": avg_entropy(text, self.lm_scorer),
+        }
+        combined = {**lm_metrics, **stats}
+        return combined
+
+    def _evaluate_rules(self, features: Dict[str, float], thresholds: Dict[str, float]) -> List[str]:
+        reasons: List[str] = []
+        if "max_ppl" in thresholds and features["ppl"] > thresholds["max_ppl"]:
+            reasons.append(f"ppl {features['ppl']:.2f} exceeds max {thresholds['max_ppl']:.2f}")
+        if "max_ngram_repeat" in thresholds and features["ngram_repeat_ratio"] > thresholds["max_ngram_repeat"]:
+            reasons.append(
+                "ngram repeat ratio "
+                f"{features['ngram_repeat_ratio']:.2f} exceeds {thresholds['max_ngram_repeat']:.2f}"
+            )
+        if "min_ttr" in thresholds and features["type_token_ratio"] < thresholds["min_ttr"]:
+            reasons.append(
+                f"type-token ratio {features['type_token_ratio']:.2f} below {thresholds['min_ttr']:.2f}"
+            )
+        if "max_avg_entropy" in thresholds and features["avg_entropy"] > thresholds["max_avg_entropy"]:
+            reasons.append(
+                f"avg entropy {features['avg_entropy']:.2f} exceeds {thresholds['max_avg_entropy']:.2f}"
+            )
+        if "min_avg_sentence_len" in thresholds and features["avg_sentence_len"] < thresholds["min_avg_sentence_len"]:
+            reasons.append(
+                "avg sentence length "
+                f"{features['avg_sentence_len']:.2f} below {thresholds['min_avg_sentence_len']:.2f}"
+            )
+        return reasons
+
+    def evaluate(self, text: str, thresholds: Dict[str, float]) -> GuardResult:
+        """Evaluate the provided text against configured thresholds."""
+
+        metrics = self._collect_metrics(text)
+        features = extract_features(metrics)
+        reasons = self._evaluate_rules(features, thresholds)
+        detector_score: Optional[float] = None
+        if self.classifier is not None and hasattr(self.classifier, "predict_proba"):
+            detector_score = float(self.classifier.predict_proba(features))
+            metrics["detector_score"] = detector_score
+            if "max_detector_score" in thresholds and detector_score > thresholds["max_detector_score"]:
+                reasons.append(
+                    "detector score "
+                    f"{detector_score:.2f} exceeds {thresholds['max_detector_score']:.2f}"
+                )
+        passed = not reasons
+        return GuardResult(passed, reasons, metrics, detector_score)

--- a/src/neuralstego/metrics/__init__.py
+++ b/src/neuralstego/metrics/__init__.py
@@ -1,0 +1,13 @@
+"""Utility functions and helpers for computing cover-text metrics."""
+
+from .lm_scorer import LMScorer
+from .text_stats import avg_sentence_len, ngram_repeat_ratio, type_token_ratio
+from .entropy import avg_entropy
+
+__all__ = [
+    "LMScorer",
+    "avg_entropy",
+    "avg_sentence_len",
+    "ngram_repeat_ratio",
+    "type_token_ratio",
+]

--- a/src/neuralstego/metrics/entropy.py
+++ b/src/neuralstego/metrics/entropy.py
@@ -1,0 +1,51 @@
+"""Entropy computations for token distributions."""
+
+from __future__ import annotations
+
+import importlib
+import math
+from collections import Counter
+from typing import Iterable
+
+from .lm_scorer import LMScorer
+
+
+def _tokenize(text: str) -> Iterable[str]:
+    return [token for token in text.strip().split() if token]
+
+
+def _fallback_entropy(text: str) -> float:
+    tokens = list(_tokenize(text))
+    if not tokens:
+        return 0.0
+    counts = Counter(tokens)
+    total = len(tokens)
+    entropy = 0.0
+    for count in counts.values():
+        probability = count / total
+        entropy -= probability * math.log(probability)
+    return entropy
+
+
+def avg_entropy(text: str, lm_scorer: LMScorer | None = None) -> float:
+    """Compute the average next-token entropy for the provided text."""
+
+    tokens = list(_tokenize(text))
+    if not tokens:
+        return 0.0
+    scorer = lm_scorer or LMScorer()
+    if not scorer._transformers_available():
+        return _fallback_entropy(text)
+    scorer._ensure_transformers_model()
+    tokenizer = scorer._tokenizer
+    model = scorer._model
+    assert tokenizer is not None and model is not None
+    inputs = tokenizer(text, return_tensors="pt")
+    torch = importlib.import_module("torch")
+    with torch.no_grad():
+        outputs = model(**inputs)
+    logits = outputs.logits
+    probabilities = torch.nn.functional.softmax(logits[:, :-1, :], dim=-1)
+    entropy = -torch.sum(probabilities * torch.log(probabilities + 1e-12), dim=-1)
+    mean_entropy = float(torch.mean(entropy))
+    return mean_entropy

--- a/src/neuralstego/metrics/lm_scorer.py
+++ b/src/neuralstego/metrics/lm_scorer.py
@@ -1,0 +1,108 @@
+"""Language model scoring utilities for cover-text analysis."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import math
+from collections import Counter
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+
+@dataclass
+class _FallbackDistribution:
+    """Light-weight empirical distribution used when transformers are unavailable."""
+
+    counts: Counter[str]
+    total: int
+
+    def nll(self, sequence: Iterable[str]) -> float:
+        """Compute the total negative log likelihood for the provided sequence."""
+
+        nll_value = 0.0
+        for token in sequence:
+            probability = self.counts[token] / self.total
+            nll_value -= math.log(probability)
+        return nll_value
+
+    def entropy(self) -> float:
+        """Return the Shannon entropy of the empirical token distribution."""
+
+        entropy_sum = 0.0
+        for count in self.counts.values():
+            probability = count / self.total
+            entropy_sum -= probability * math.log(probability)
+        return entropy_sum
+
+
+class LMScorer:
+    """Score text using GPT2-fa when available, otherwise a deterministic fallback."""
+
+    _model = None
+    _tokenizer = None
+
+    def __init__(
+        self,
+        model_name: str = "HooshvareLab/gpt2-fa",
+        prefer_transformers: bool = True,
+    ) -> None:
+        self.model_name = model_name
+        self.prefer_transformers = prefer_transformers
+        self._backend = "transformers" if prefer_transformers else "fallback"
+
+    def _transformers_available(self) -> bool:
+        if self._backend != "transformers":
+            return False
+        return importlib.util.find_spec("transformers") is not None
+
+    def _ensure_transformers_model(self) -> None:
+        if not self._transformers_available():
+            raise RuntimeError("transformers is not available in the current environment")
+        if self.__class__._model is not None:
+            return
+        transformers = importlib.import_module("transformers")
+        tokenizer = transformers.AutoTokenizer.from_pretrained(self.model_name)
+        model = transformers.AutoModelForCausalLM.from_pretrained(self.model_name)
+        model.eval()
+        self.__class__._tokenizer = tokenizer
+        self.__class__._model = model
+
+    @staticmethod
+    def _tokenize(text: str) -> Iterable[str]:
+        return [token for token in text.strip().split() if token]
+
+    @staticmethod
+    def _fallback_score(tokens: Iterable[str]) -> Dict[str, float]:
+        token_list = list(tokens)
+        if not token_list:
+            return {"ppl": 0.0, "avg_nll": 0.0, "token_count": 0}
+        distribution = _FallbackDistribution(Counter(token_list), len(token_list))
+        total_nll = distribution.nll(token_list)
+        token_count = len(token_list)
+        avg_nll = total_nll / token_count
+        ppl = math.exp(avg_nll)
+        return {"ppl": ppl, "avg_nll": avg_nll, "token_count": token_count}
+
+    def score(self, text: str) -> Dict[str, float]:
+        """Compute perplexity, average negative log likelihood, and token count."""
+
+        tokens = self._tokenize(text)
+        if not tokens:
+            return {"ppl": 0.0, "avg_nll": 0.0, "token_count": 0}
+        if not self._transformers_available():
+            return self._fallback_score(tokens)
+
+        self._ensure_transformers_model()
+        tokenizer = self.__class__._tokenizer
+        model = self.__class__._model
+        assert tokenizer is not None and model is not None
+        inputs = tokenizer(text, return_tensors="pt")
+        torch = importlib.import_module("torch")
+        with torch.no_grad():
+            outputs = model(**inputs, labels=inputs["input_ids"])
+        loss = float(outputs.loss)
+        avg_nll = loss
+        ppl = math.exp(avg_nll)
+        token_count = int(inputs["input_ids"].shape[1])
+        return {"ppl": ppl, "avg_nll": avg_nll, "token_count": token_count}

--- a/src/neuralstego/metrics/text_stats.py
+++ b/src/neuralstego/metrics/text_stats.py
@@ -1,0 +1,51 @@
+"""Text-level statistics helpers for quick heuristics."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import List
+
+_SENTENCE_PATTERN = re.compile(r"[.!؟?\n]+")
+
+
+def _tokenize(text: str) -> List[str]:
+    return [token for token in re.split(r"\s+", text.strip()) if token]
+
+
+def _sentences(text: str) -> List[str]:
+    raw = [segment.strip() for segment in _SENTENCE_PATTERN.split(text) if segment.strip()]
+    return raw or ([text.strip()] if text.strip() else [])
+
+
+def ngram_repeat_ratio(text: str, n: int = 3) -> float:
+    """Return the ratio of repeated n-grams in the text."""
+
+    tokens = _tokenize(text)
+    if len(tokens) < n or n <= 0:
+        return 0.0
+    ngrams = [tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1)]
+    counts = Counter(ngrams)
+    total = len(ngrams)
+    repeated = sum(count for count in counts.values() if count > 1)
+    return repeated / total if total else 0.0
+
+
+def type_token_ratio(text: str) -> float:
+    """Compute the type-token ratio for the provided text."""
+
+    tokens = _tokenize(text)
+    if not tokens:
+        return 0.0
+    unique = {token.lower() for token in tokens}
+    return len(unique) / len(tokens)
+
+
+def avg_sentence_len(text: str) -> float:
+    """Return the average number of tokens per sentence."""
+
+    sentences = _sentences(text)
+    if not sentences:
+        return 0.0
+    token_counts = [len(_tokenize(sentence)) for sentence in sentences]
+    return sum(token_counts) / len(token_counts)

--- a/tests/detect/test_features.py
+++ b/tests/detect/test_features.py
@@ -1,0 +1,14 @@
+from neuralstego.detect import EXPECTED_FEATURES, extract_features
+
+
+def test_extract_features_returns_all_keys():
+    metrics = {
+        "ppl": 10.0,
+        "avg_nll": 2.0,
+        "avg_entropy": 1.5,
+        "ngram_repeat_ratio": 0.1,
+        "type_token_ratio": 0.6,
+        "avg_sentence_len": 12.0,
+    }
+    features = extract_features(metrics)
+    assert tuple(features.keys()) == EXPECTED_FEATURES

--- a/tests/detect/test_guard_rules.py
+++ b/tests/detect/test_guard_rules.py
@@ -1,0 +1,30 @@
+from neuralstego.detect.guard import QualityGuard
+from neuralstego.metrics import LMScorer
+
+
+SAMPLE_TEXT = """
+سلام دنیا. این متن آزمایشی برای بررسی نگهبان کیفیت است.
+""".strip()
+
+
+def test_quality_guard_passes_when_within_thresholds():
+    guard = QualityGuard(lm_scorer=LMScorer(prefer_transformers=False))
+    thresholds = {
+        "max_ppl": 100.0,
+        "max_ngram_repeat": 0.5,
+        "min_ttr": 0.2,
+        "max_avg_entropy": 5.0,
+        "min_avg_sentence_len": 2.0,
+    }
+    result = guard.evaluate(SAMPLE_TEXT, thresholds)
+    assert result.passed
+    assert not result.reasons
+    assert result.metrics["ppl"] > 0
+
+
+def test_quality_guard_flags_threshold_breach():
+    guard = QualityGuard(lm_scorer=LMScorer(prefer_transformers=False))
+    thresholds = {"max_ppl": 0.1}
+    result = guard.evaluate(SAMPLE_TEXT, thresholds)
+    assert not result.passed
+    assert result.reasons

--- a/tests/metrics/test_entropy.py
+++ b/tests/metrics/test_entropy.py
@@ -1,0 +1,8 @@
+from neuralstego.metrics import LMScorer
+from neuralstego.metrics.entropy import avg_entropy
+
+
+def test_entropy_positive_for_sample_text():
+    scorer = LMScorer(prefer_transformers=False)
+    entropy_value = avg_entropy("این یک متن کوتاه است", lm_scorer=scorer)
+    assert entropy_value >= 0.0

--- a/tests/metrics/test_lm_scorer.py
+++ b/tests/metrics/test_lm_scorer.py
@@ -1,0 +1,10 @@
+from neuralstego.metrics import LMScorer
+
+
+def test_lm_scorer_returns_basic_metrics():
+    scorer = LMScorer(prefer_transformers=False)
+    result = scorer.score("این یک متن آزمایشی است")
+    assert set(result.keys()) == {"ppl", "avg_nll", "token_count"}
+    assert result["token_count"] > 0
+    assert result["ppl"] > 0
+    assert result["avg_nll"] >= 0

--- a/tests/metrics/test_text_stats.py
+++ b/tests/metrics/test_text_stats.py
@@ -1,0 +1,21 @@
+from neuralstego.metrics import avg_sentence_len, ngram_repeat_ratio, type_token_ratio
+
+
+SAMPLE_TEXT = """
+سلام دنیا. این یک نمونه ساده برای آزمایش است. این نمونه شامل چند جمله کوتاه است.
+""".strip()
+
+
+def test_ngram_repeat_ratio_bounds():
+    ratio = ngram_repeat_ratio(SAMPLE_TEXT, n=2)
+    assert 0.0 <= ratio <= 1.0
+
+
+def test_type_token_ratio_bounds():
+    ttr = type_token_ratio(SAMPLE_TEXT)
+    assert 0.0 <= ttr <= 1.0
+
+
+def test_average_sentence_length_positive():
+    avg_len = avg_sentence_len(SAMPLE_TEXT)
+    assert avg_len > 0


### PR DESCRIPTION
## Summary
- implement a metrics package with LM scoring, entropy, and text statistic helpers
- add a detection guard with rule-based thresholds, feature extraction, and optional classifier support
- cover the new behaviour with focused unit tests for metrics and guard orchestration

## Testing
- `pytest` *(fails: missing optional dependencies such as numpy, torch, and cryptography in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e9f5996ab0833294f80fa6a5a46b9f