### PR TITLE
Add quality gate regeneration and CLI audit tools

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -9,6 +9,7 @@
 - **Crypto Agent:** طراحی و بازبینی طرح‌های رمزنگاری (AES/AEAD)، مدیریت کلید و سیاست امنیت.
 - **Algorithm Agent:** مسئول رمزگذاری حسابی، APIهای encode/decode و کنترل پارامترهای کیفیت/ظرفیت.
 - **CLI/DevOps Agent:** توسعه CLI، اسکریپت‌ها، Makefile، pre-commit و گردش‌کار CI/CD.
+- **Quality Agent:** مالک سنجه‌ها، نگهبان کشف، و هماهنگ‌کنندهٔ آستانه‌های gate/audit.
 
 ## Style Guide
 - استفادهٔ اجباری از typing و docstring‌های دقیق.

--- a/README.md
+++ b/README.md
@@ -62,22 +62,27 @@ make smoke  # اجرای اسکریپت smoke (نسخه، doctor، pytest)
 ```
 
 ## آزمون دود پوششی (Cover Smoke)
-برای آزمایش سریع جریان cover می‌توانید اسکریپت جدید را اجرا کنید:
+برای آزمایش سریع جریان cover می‌توانید اسکریپت‌های دود زیر را اجرا کنید:
 
 ```bash
-bash scripts/cover_smoke.sh
+bash scripts/cover_smoke.sh          # دود کلاسیک بدون نگهبان کیفیت
+bash scripts/quality_smoke.sh        # دود همراه با gate و audit
+bash scripts/audit_many.sh           # تولید مجموعه‌ای از کاورها و ممیزی گروهی
 ```
 
-این اسکریپت یک پیام محرمانهٔ نمونه می‌سازد، آن را با رمز عبور در یک متن پوششی جاسازی می‌کند و سه خط اول خروجی را نمایش می‌دهد. در صورت نیاز به بازیابی دستی، می‌توانید از دستورات زیر (با به‌روزرسانی مسیرها و seed) استفاده کنید:
+این اسکریپت‌ها پیام‌های محرمانهٔ نمونه می‌سازند، آن‌ها را در متون پوششی جاسازی می‌کنند و نتیجهٔ نگهبان کیفیت و ممیزی را گزارش می‌دهند. در صورت نیاز به اجرای دستی، می‌توانید از دستورات زیر (با به‌روزرسانی مسیرها و seed) استفاده کنید:
 
 ```bash
 neuralstego cover-generate -p "Pa$$w0rd" -i secret.txt -o cover.txt \
   --seed "در یک گفت‌وگوی کوتاه درباره‌ی فناوری و اخبار روز صحبت می‌کنیم." \
   --quality top-k 60 --quality temperature 0.8 \
-  --chunk-bytes 256 --crc on --ecc rs --nsym 10
+  --quality-gate on --max-ppl 100 --max-ngram-repeat 0.25 --min-ttr 0.30 \
+  --regen-attempts 2 --chunk-bytes 256 --crc on --ecc rs --nsym 10
 
 neuralstego cover-reveal -p "Pa$$w0rd" -i cover.txt -o recovered.txt \
   --seed "در یک گفت‌وگوی کوتاه درباره‌ی فناوری و اخبار روز صحبت می‌کنیم."
+
+neuralstego quality-audit -i cover.txt --max-ppl 100 --max-ngram-repeat 0.25 --min-ttr 0.30
 ```
 
 ## ساختار معماری و فازها

--- a/arithmetic.py
+++ b/arithmetic.py
@@ -12,8 +12,10 @@ from utils import bits2int, entropy, int2bits, is_sent_finish, kl, limit_past, n
 def _prepare_past_for_model(past):
     if past is None:
         return None
-    if isinstance(past, list):
-        return tuple(past)
+    if isinstance(past, DynamicCache):
+        return past
+    if isinstance(past, (list, tuple)):
+        return DynamicCache.from_legacy_cache(tuple(past))
     return past
 
 

--- a/scripts/audit_many.sh
+++ b/scripts/audit_many.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+SEEDS=(
+  "در یک گفت‌وگوی کوتاه درباره‌ی فناوری صحبت می‌کنیم."
+  "امروز درباره‌ی کتاب‌ها و هنر صحبت می‌کنیم."
+  "وضعیت بازار و اقتصاد را مرور می‌کنیم."
+  "از خاطرات سفر و طبیعت حرف می‌زنیم."
+  "کمی درباره‌ی ورزش و سلامت صحبت می‌کنیم."
+)
+
+SECRETS=(
+  "جلسه‌ی تیمی فردا ساعت ۱۰ برگزار می‌شود."
+  "پروتوتایپ نسخه‌ی جدید آماده است؛ لطفاً بازخورد بدهید."
+  "رمز عبور ایمیل تا پایان هفته تغییر خواهد کرد."
+)
+
+printf "secret\tseed\tcover\tquality\n"
+
+for secret_idx in "${!SECRETS[@]}"; do
+  secret_label=$(printf "S%02d" "$((secret_idx + 1))")
+  secret_path="${TMP}/secret_${secret_idx}.txt"
+  printf '%s' "${SECRETS[$secret_idx]}" > "${secret_path}"
+
+  for seed_idx in "${!SEEDS[@]}"; do
+    seed_label=$(printf "seed%02d" "$((seed_idx + 1))")
+    seed_text="${SEEDS[$seed_idx]}"
+    cover_path="${TMP}/cover_${secret_idx}_${seed_idx}.txt"
+
+    cover_status="pass"
+    if ! neuralstego cover-generate \
+      -i "${secret_path}" \
+      -o "${cover_path}" \
+      --seed "${seed_text}" \
+      --quality top-k 70 --quality temperature 0.8 \
+      --quality-gate on \
+      --max-ppl 110 \
+      --max-ngram-repeat 0.30 \
+      --min-ttr 0.28 \
+      --regen-attempts 2 >/dev/null; then
+      cover_status="fail"
+    fi
+
+    if [ ! -f "${cover_path}" ]; then
+      touch "${cover_path}"
+    fi
+
+    audit_status="pass"
+    if ! neuralstego quality-audit -i "${cover_path}" --max-ppl 110 --max-ngram-repeat 0.30 --min-ttr 0.28 >/dev/null; then
+      audit_status="fail"
+    fi
+
+    printf "%s\t%s\t%s\t%s\n" "${secret_label}" "${seed_label}" "${cover_status}" "${audit_status}"
+  done
+done

--- a/scripts/quality_smoke.sh
+++ b/scripts/quality_smoke.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+
+echo "گزارش سری: جلسه اصلی فردا ساعت ۱۵ برگزار می‌شود." > "${TMP}/secret.txt"
+
+neuralstego cover-generate \
+  -p "Pa$$w0rd" \
+  -i "${TMP}/secret.txt" \
+  -o "${TMP}/cover.txt" \
+  --seed "در یک گفت‌وگوی کوتاه درباره‌ی فناوری و اخبار روز صحبت می‌کنیم." \
+  --quality top-k 60 --quality temperature 0.8 \
+  --quality-gate on \
+  --max-ppl 100 \
+  --max-ngram-repeat 0.25 \
+  --min-ttr 0.30 \
+  --regen-attempts 2
+
+neuralstego quality-audit -i "${TMP}/cover.txt"
+
+word_count=$(wc -w < "${TMP}/cover.txt")
+echo "[OK] Quality smoke completed: ${word_count} words"

--- a/src/neuralstego/exceptions.py
+++ b/src/neuralstego/exceptions.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List
 
 
 class NeuralStegoError(Exception):
@@ -35,6 +35,21 @@ class MissingChunksError(FramingError):
         return f"Missing chunks at indices: {indices}"
 
 
+@dataclass
+class QualityGateError(NeuralStegoError):
+    """Raised when the quality gate rejects all cover-generation attempts."""
+
+    cover_text: str
+    reasons: List[str]
+    metrics: Dict[str, float]
+
+    def __str__(self) -> str:  # pragma: no cover - human-friendly message
+        if not self.reasons:
+            return "quality gate rejected the generated cover"
+        joined = "; ".join(self.reasons)
+        return f"quality gate rejected the generated cover: {joined}"
+
+
 __all__ = [
     "ConfigurationError",
     "FramingError",
@@ -42,4 +57,5 @@ __all__ = [
     "NeuralStegoError",
     "PacketCRCError",
     "PacketECCError",
+    "QualityGateError",
 ]

--- a/tests/api/test_cover_api.py
+++ b/tests/api/test_cover_api.py
@@ -8,7 +8,16 @@ def test_cover_generate_returns_text_with_mock_lm():
     lm = MockLM()
     secret = "راز مخفی"
     seed = "این یک متن پایه است"
-    cover_text = cover_generate(secret, seed_text=seed, quality={}, use_crc=False, ecc="none", nsym=0, lm=lm)
+    cover_text = cover_generate(
+        secret,
+        seed_text=seed,
+        quality={},
+        use_crc=False,
+        ecc="none",
+        nsym=0,
+        lm=lm,
+        quality_gate=False,
+    )
     assert isinstance(cover_text, str)
     assert cover_text
 

--- a/tests/quality/test_guard_cli.py
+++ b/tests/quality/test_guard_cli.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from neuralstego import cli as cli_module  # noqa: E402
+from neuralstego.detect.guard import GuardResult  # noqa: E402
+from neuralstego.exceptions import QualityGateError  # noqa: E402
+
+
+def _run_cli(*args: str) -> int:
+    return cli_module.main(list(args))
+
+
+def test_cover_generate_forwards_quality_gate_options(monkeypatch, tmp_path, capsys):
+    secret_path = tmp_path / "secret.txt"
+    secret_path.write_text("راز", encoding="utf-8")
+    output_path = tmp_path / "cover.txt"
+    seed_pool_path = tmp_path / "seeds.txt"
+    seed_pool_path.write_text("بذر دوم\nبذر سوم\n", encoding="utf-8")
+
+    calls: dict[str, object] = {}
+
+    def fake_cover_generate(secret: bytes, **kwargs):
+        calls["secret"] = secret
+        calls["kwargs"] = kwargs
+        return "متن کاور"
+
+    monkeypatch.setattr(cli_module, "api_cover_generate", fake_cover_generate)
+
+    exit_code = _run_cli(
+        "cover-generate",
+        "-i",
+        str(secret_path),
+        "-o",
+        str(output_path),
+        "--seed",
+        "بذر اصلی",
+        "--quality-gate",
+        "on",
+        "--max-ppl",
+        "90",
+        "--max-detector-score",
+        "0.4",
+        "--max-ngram-repeat",
+        "0.2",
+        "--min-ttr",
+        "0.3",
+        "--regen-attempts",
+        "3",
+        "--regen-seed-pool",
+        str(seed_pool_path),
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.out
+    assert "classifier is not configured" in captured.out
+    assert output_path.read_text(encoding="utf-8") == "متن کاور"
+
+    kwargs = calls["kwargs"]
+    assert kwargs["quality_gate"] is True
+    assert kwargs["gate_thresholds"] == {
+        "max_ppl": 90.0,
+        "max_detector_score": 0.4,
+        "max_ngram_repeat": 0.2,
+        "min_ttr": 0.3,
+    }
+    assert kwargs["regen_attempts"] == 3
+    assert kwargs["regen_strategy"] == {"seed_pool": ["بذر دوم", "بذر سوم"]}
+    assert kwargs["quality_guard"] is cli_module.QUALITY_GUARD
+    assert kwargs["seed_text"] == "بذر اصلی"
+    assert calls["secret"] == secret_path.read_bytes()
+
+
+def test_cover_generate_reports_quality_gate_failure(monkeypatch, tmp_path, capsys):
+    secret_path = tmp_path / "secret.txt"
+    secret_path.write_text("راز", encoding="utf-8")
+    output_path = tmp_path / "cover.txt"
+
+    def fake_cover_generate(*_, **__):
+        raise QualityGateError(
+            "متن ضعیف",
+            ["ppl 200.0 exceeds max 90.0"],
+            {"ppl": 200.0, "type_token_ratio": 0.15},
+        )
+
+    monkeypatch.setattr(cli_module, "api_cover_generate", fake_cover_generate)
+
+    exit_code = _run_cli(
+        "cover-generate",
+        "-i",
+        str(secret_path),
+        "-o",
+        str(output_path),
+        "--seed",
+        "بذر اصلی",
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert output_path.read_text(encoding="utf-8") == "متن ضعیف"
+    assert "Quality gate rejected" in captured.out
+    assert "ppl" in captured.out
+    assert "- ppl 200.0 exceeds max 90.0" in captured.out
+
+
+def test_quality_audit_reports_metrics(monkeypatch, tmp_path, capsys):
+    cover_path = tmp_path / "cover.txt"
+    cover_path.write_text("متن کاور", encoding="utf-8")
+
+    class StubGuard:
+        classifier = None
+
+        def __init__(self, result: GuardResult) -> None:
+            self.result = result
+            self.calls = 0
+            self.thresholds = None
+            self.text = ""
+
+        def evaluate(self, text, thresholds):
+            self.calls += 1
+            self.text = text
+            self.thresholds = thresholds
+            return self.result
+
+    result = GuardResult(True, [], {"ppl": 32.0, "type_token_ratio": 0.41, "avg_entropy": 2.3})
+    guard = StubGuard(result)
+    monkeypatch.setattr(cli_module, "QUALITY_GUARD", guard)
+
+    exit_code = _run_cli(
+        "quality-audit",
+        "-i",
+        str(cover_path),
+        "--max-ppl",
+        "80",
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert guard.calls == 1
+    assert guard.thresholds["max_ppl"] == 80.0
+    assert "Quality metrics" in captured.out
+    assert "PASS" in captured.out
+
+
+def test_quality_audit_exits_nonzero_on_failure(monkeypatch, tmp_path, capsys):
+    cover_path = tmp_path / "cover.txt"
+    cover_path.write_text("متن تکراری", encoding="utf-8")
+
+    class StubGuard:
+        classifier = None
+
+        def __init__(self, result: GuardResult) -> None:
+            self.result = result
+
+        def evaluate(self, text, thresholds):
+            return self.result
+
+    result = GuardResult(False, ["ppl 150.0 exceeds max 90.0"], {"ppl": 150.0})
+    guard = StubGuard(result)
+    monkeypatch.setattr(cli_module, "QUALITY_GUARD", guard)
+
+    exit_code = _run_cli(
+        "quality-audit",
+        "-i",
+        str(cover_path),
+        "--max-ppl",
+        "90",
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "FAIL" in captured.out
+    assert "Reasons" in captured.out

--- a/tests/quality/test_regen_loop.py
+++ b/tests/quality/test_regen_loop.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from neuralstego.api import cover_generate
+from neuralstego.detect.guard import GuardResult
+from neuralstego.exceptions import QualityGateError
+from neuralstego.lm.mock import MockLM
+
+
+class _ToggleGuard:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.texts: list[str] = []
+
+    def evaluate(self, text: str, thresholds):
+        self.calls += 1
+        self.texts.append(text)
+        if self.calls == 1:
+            return GuardResult(False, ["ppl too high"], {"ppl": 420.0, "type_token_ratio": 0.10})
+        return GuardResult(True, [], {"ppl": 48.0, "type_token_ratio": 0.36})
+
+
+class _FailingGuard:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.texts: list[str] = []
+
+    def evaluate(self, text: str, thresholds):
+        self.calls += 1
+        self.texts.append(text)
+        return GuardResult(False, ["ngram repeat"], {"ppl": 510.0, "type_token_ratio": 0.12})
+
+
+def test_cover_generate_regenerates_until_guard_passes():
+    guard = _ToggleGuard()
+    lm = MockLM()
+
+    cover_text = cover_generate(
+        "داده محرمانه",
+        seed_text="مکالمه پایه",
+        quality={},
+        use_crc=False,
+        ecc="none",
+        nsym=0,
+        lm=lm,
+        regen_attempts=2,
+        regen_strategy={"seed_pool": ["مکالمه جایگزین"]},
+        quality_guard=guard,
+    )
+
+    assert guard.calls == 2
+    assert cover_text.startswith("مکالمه جایگزین")
+
+
+def test_cover_generate_raises_quality_error_after_exhausting_attempts():
+    guard = _FailingGuard()
+    lm = MockLM()
+
+    with pytest.raises(QualityGateError) as excinfo:
+        cover_generate(
+            "داده محرمانه",
+            seed_text="گفت‌وگوی اولیه",
+            quality={},
+            use_crc=False,
+            ecc="none",
+            nsym=0,
+            lm=lm,
+            regen_attempts=1,
+            regen_strategy={"seed_pool": ["گفت‌وگوی دوم"]},
+            quality_guard=guard,
+        )
+
+    assert guard.calls == 2
+    error = excinfo.value
+    assert error.cover_text.startswith("گفت‌وگوی دوم")
+    assert "ngram" in " ".join(error.reasons)
+    assert error.metrics["ppl"] == pytest.approx(510.0)


### PR DESCRIPTION
## Summary
- add default quality gate thresholds and regeneration loop to `cover_generate`, surfacing a structured `QualityGateError`
- extend the CLI with quality-gate options, seed-pool regeneration, and a new `quality-audit` subcommand
- document and script quality smoke/audit workflows and add targeted regression tests

## Testing
- pytest tests/quality tests/api/test_cover_api.py tests/crypto/test_cli_gpt2fa.py
- pytest tests/quality/test_regen_loop.py
- pytest tests/api/test_cover_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e9fcdef4648332bad4f8007c856ae2