### PR TITLE
Improve typing across codec and CLI layers

### DIFF
--- a/src/neuralstego/api.py
+++ b/src/neuralstego/api.py
@@ -22,9 +22,9 @@ from typing import (
 )
 
 try:  # pragma: no cover - optional dependency for pretty logging
-    from rich.console import Console  # type: ignore[import-not-found]
+    from rich.console import Console as _RichConsole  # type: ignore[import-not-found]
 except ModuleNotFoundError:  # pragma: no cover - graceful fallback when rich is absent
-    Console = None
+    _RichConsole = None
 
 from .codec import assemble_bytes, build_packet, chunk_bytes, make_msg_id, parse_packet
 from .codec.packet import RSCodec as _RSCodec  # type: ignore[attr-defined]
@@ -107,7 +107,17 @@ DEFAULT_REGEN_STRATEGY: Dict[str, Any] = {
 }
 
 
-_QUALITY_CONSOLE = Console(stderr=True) if Console is not None else None
+class _ConsoleLogger(Protocol):
+    def log(self, message: str, *args: object, **kwargs: object) -> None:
+        ...
+
+
+if _RichConsole is not None:
+    _QUALITY_CONSOLE: _ConsoleLogger | None = cast(
+        _ConsoleLogger, _RichConsole(stderr=True)
+    )
+else:
+    _QUALITY_CONSOLE = None
 
 
 def _quality_log(message: str) -> None:

--- a/src/neuralstego/codec/arithmetic.py
+++ b/src/neuralstego/codec/arithmetic.py
@@ -405,12 +405,15 @@ def _rank_tokens(dist: ProbDist) -> Tuple[List[int], int]:
 
 def _dist_to_arrays(dist: ProbDist) -> Tuple[NDArray[np.int_], NDArray[np.float64]]:
     if isinstance(dist, np.ndarray):
-        tokens = np.arange(dist.size, dtype=np.int64)
+        tokens = cast(NDArray[np.int_], np.arange(dist.size, dtype=np.int64))
         probs = np.asarray(dist, dtype=np.float64)
         return tokens, probs
     if isinstance(dist, dict):
         items = sorted(dist.items())
-        tokens = np.array([int(token) for token, _ in items], dtype=np.int64)
+        tokens = cast(
+            NDArray[np.int_],
+            np.array([int(token) for token, _ in items], dtype=np.int64),
+        )
         probs = np.array([float(prob) for _, prob in items], dtype=np.float64)
         return tokens, probs
     raise TypeError(f"Unsupported probability distribution type: {type(dist)!r}")

--- a/src/neuralstego/codec/quality.py
+++ b/src/neuralstego/codec/quality.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -145,10 +145,13 @@ def cap_bits_per_token(dist: ProbDist, cap_per_token_bits: int) -> ProbDist:
 def _dist_to_arrays(dist: ProbDist) -> tuple[NDArray[np.int_], NDArray[np.float64]]:
     if isinstance(dist, np.ndarray):
         probs = np.asarray(dist, dtype=np.float64)
-        tokens = np.arange(probs.size, dtype=np.int64)
+        tokens = cast(NDArray[np.int_], np.arange(probs.size, dtype=np.int64))
     elif isinstance(dist, dict):
         items = sorted(dist.items())
-        tokens = np.array([int(token) for token, _ in items], dtype=np.int64)
+        tokens = cast(
+            NDArray[np.int_],
+            np.array([int(token) for token, _ in items], dtype=np.int64),
+        )
         probs = np.array([float(prob) for _, prob in items], dtype=np.float64)
     else:
         raise TypeError(f"Unsupported distribution type: {type(dist)!r}")

--- a/src/neuralstego/crypto/aead.py
+++ b/src/neuralstego/crypto/aead.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from os import urandom
 from typing import Final
 
-from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM  # type: ignore[import-not-found]
 
 __all__ = [
     "NONCE_SIZE",

--- a/src/neuralstego/crypto/arithmetic.py
+++ b/src/neuralstego/crypto/arithmetic.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping, MutableMapping, Sequence
+from typing import Mapping, Sequence, cast
 
-from ..codec.arithmetic import decode_with_lm, encode_with_lm
+from ..codec.arithmetic import (
+    _coerce_optional_float,
+    _coerce_optional_int,
+    decode_with_lm,
+    encode_with_lm,
+)
 from ..codec.types import CodecState, LMProvider, ProbDist
 from .quality import apply_quality
 
@@ -46,12 +51,17 @@ def encode_arithmetic(
     *,
     quality: Mapping[str, object] | None = None,
     seed_text: Sequence[int] | None = None,
-    state: MutableMapping[str, object] | None = None,
+    state: CodecState | None = None,
 ) -> tuple[list[int], CodecState]:
     """Encode ``payload`` bits using ``lm`` with the provided quality policies."""
 
     policies = _extract_quality(quality)
-    controlled = _QualityControlledLM(lm, **policies)
+    controlled = _QualityControlledLM(
+        lm,
+        top_k=policies.top_k,
+        top_p=policies.top_p,
+        temperature=policies.temperature,
+    )
 
     encode_state: CodecState = {}
     tokens = encode_with_lm(payload, controlled, context=tuple(seed_text or ()), state=encode_state)
@@ -68,7 +78,7 @@ def decode_arithmetic(
     *,
     quality: Mapping[str, object] | None = None,
     seed_text: Sequence[int] | None = None,
-    state: MutableMapping[str, object] | None = None,
+    state: CodecState | None = None,
 ) -> bytes:
     """Decode ``token_ids`` into the embedded payload bits."""
 
@@ -76,10 +86,18 @@ def decode_arithmetic(
         raise ValueError("state with bit consumption history is required for decoding")
 
     policies = _extract_quality(quality)
-    controlled = _QualityControlledLM(lm, **policies)
+    controlled = _QualityControlledLM(
+        lm,
+        top_k=policies.top_k,
+        top_p=policies.top_p,
+        temperature=policies.temperature,
+    )
 
     decode_state: CodecState = {"history": tuple(), "residual_bits": b""}
-    decode_state.update(state)  # type: ignore[arg-type]
+    if "history" in state:
+        decode_state["history"] = cast(Sequence[int], state["history"])
+    if "residual_bits" in state:
+        decode_state["residual_bits"] = cast(bytes, state["residual_bits"])
 
     return decode_with_lm(
         token_ids,
@@ -89,24 +107,25 @@ def decode_arithmetic(
     )
 
 
-def _extract_quality(quality: Mapping[str, object] | None) -> dict[str, object]:
+@dataclass(frozen=True)
+class _QualityPolicies:
+    top_k: int | None
+    top_p: float | None
+    temperature: float
+
+
+def _extract_quality(quality: Mapping[str, object] | None) -> _QualityPolicies:
     if not quality:
-        return {"top_k": None, "top_p": None, "temperature": 1.0}
+        return _QualityPolicies(top_k=None, top_p=None, temperature=1.0)
 
-    policies: dict[str, object] = {}
-    if "top_k" in quality:
-        policies["top_k"] = int(quality["top_k"]) if quality["top_k"] is not None else None
-    else:
-        policies["top_k"] = None
+    top_k = quality.get("top_k")
+    top_p = quality.get("top_p")
+    temperature = quality.get("temperature", 1.0)
 
-    if "top_p" in quality:
-        policies["top_p"] = float(quality["top_p"]) if quality["top_p"] is not None else None
-    else:
-        policies["top_p"] = None
+    coerced_top_k = _coerce_optional_int(top_k, "top_k")
+    coerced_top_p = _coerce_optional_float(top_p, "top_p")
+    if isinstance(temperature, bool) or not isinstance(temperature, (int, float)):
+        raise TypeError("temperature must be a real number")
+    coerced_temperature = float(temperature)
 
-    if "temperature" in quality:
-        policies["temperature"] = float(quality["temperature"])
-    else:
-        policies["temperature"] = 1.0
-
-    return policies
+    return _QualityPolicies(top_k=coerced_top_k, top_p=coerced_top_p, temperature=coerced_temperature)

--- a/src/neuralstego/crypto/gpt2fa.py
+++ b/src/neuralstego/crypto/gpt2fa.py
@@ -109,7 +109,10 @@ def decode_text(payload: Mapping[str, object], password: str) -> str:
     if not isinstance(payload, Mapping):
         raise TypeError("Payload must be a mapping produced by encode_text.")
 
-    encoding = payload.get("encoding", "utf-8")
+    encoding_obj = payload.get("encoding", "utf-8")
+    if not isinstance(encoding_obj, str):
+        raise ValueError("Payload encoding must be a string.")
+    encoding = encoding_obj
     raw_tokens = payload.get("tokens")
     if not isinstance(raw_tokens, Sequence):
         raise ValueError("Payload does not contain token sequence.")

--- a/src/neuralstego/crypto/quality.py
+++ b/src/neuralstego/crypto/quality.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..codec.errors import QualityConfigError
 from ..codec.types import ProbDist
@@ -89,9 +90,9 @@ def apply_quality(
     return _arrays_to_dist(tokens, filtered, dist)
 
 
-def _dist_to_arrays(dist: ProbDist) -> tuple[np.ndarray, np.ndarray]:
+def _dist_to_arrays(dist: ProbDist) -> tuple[NDArray[np.int_], NDArray[np.float64]]:
     if isinstance(dist, np.ndarray):
-        probs = dist.astype(np.float64, copy=True)
+        probs = np.asarray(dist, dtype=np.float64)
         tokens = np.arange(probs.size, dtype=np.int64)
         return tokens, probs
     if isinstance(dist, dict):
@@ -103,8 +104,8 @@ def _dist_to_arrays(dist: ProbDist) -> tuple[np.ndarray, np.ndarray]:
 
 
 def _arrays_to_dist(
-    tokens: np.ndarray,
-    probs: np.ndarray,
+    tokens: NDArray[np.int_],
+    probs: NDArray[np.float64],
     original: ProbDist,
 ) -> ProbDist:
     if isinstance(original, np.ndarray):
@@ -119,7 +120,7 @@ def _arrays_to_dist(
     return mapping
 
 
-def _normalise(values: np.ndarray) -> np.ndarray:
+def _normalise(values: NDArray[np.float64]) -> NDArray[np.float64]:
     total = float(values.sum())
     if not math.isfinite(total) or total <= 0.0:
         raise QualityConfigError("Probability mass vanished during normalisation")

--- a/src/neuralstego/crypto/quality.py
+++ b/src/neuralstego/crypto/quality.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from typing import cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -93,11 +94,14 @@ def apply_quality(
 def _dist_to_arrays(dist: ProbDist) -> tuple[NDArray[np.int_], NDArray[np.float64]]:
     if isinstance(dist, np.ndarray):
         probs = np.asarray(dist, dtype=np.float64)
-        tokens = np.arange(probs.size, dtype=np.int64)
+        tokens = cast(NDArray[np.int_], np.arange(probs.size, dtype=np.int64))
         return tokens, probs
     if isinstance(dist, dict):
         items = sorted(dist.items())
-        tokens = np.array([int(token) for token, _ in items], dtype=np.int64)
+        tokens = cast(
+            NDArray[np.int_],
+            np.array([int(token) for token, _ in items], dtype=np.int64),
+        )
         probs = np.array([float(prob) for _, prob in items], dtype=np.float64)
         return tokens, probs
     raise TypeError(f"Unsupported distribution type: {type(dist)!r}")

--- a/src/neuralstego/framing/ecc.py
+++ b/src/neuralstego/framing/ecc.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+import importlib
+from types import ModuleType
 from typing import Tuple
 
 from .errors import NotAvailableError
 
-try:  # pragma: no cover - import guard
-    import reedsolo
-except ModuleNotFoundError:  # pragma: no cover - handled at runtime
-    reedsolo = None
+
+def _load_reedsolo() -> ModuleType | None:
+    try:
+        return importlib.import_module("reedsolo")
+    except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+        return None
 
 
-def _require_reedsolo() -> "reedsolo":
+reedsolo = _load_reedsolo()
+
+
+def _require_reedsolo() -> ModuleType:
     if reedsolo is None:
         raise NotAvailableError(
             "reedsolo is not installed. Install the 'reedsolo' package to enable ECC support."

--- a/src/neuralstego/framing/packet.py
+++ b/src/neuralstego/framing/packet.py
@@ -6,7 +6,7 @@ import base64
 import json
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Mapping, Optional
 
 from .errors import PacketValidationError, PacketVersionError
 
@@ -29,7 +29,7 @@ class ECCCfg:
         return data
 
     @classmethod
-    def from_dict(cls, data: Optional[Dict[str, Any]]) -> "ECCCfg":
+    def from_dict(cls, data: Optional[Mapping[str, Any]]) -> "ECCCfg":
         if not data:
             return cls()
         if not isinstance(data, dict):
@@ -67,8 +67,10 @@ class PacketCfg:
         return cfg
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "PacketCfg":
-        if not isinstance(data, dict):
+    def from_dict(cls, data: Optional[Mapping[str, Any]]) -> "PacketCfg":
+        if data is None:
+            data = {}
+        if not isinstance(data, Mapping):
             raise PacketValidationError("'cfg' must be an object")
         crc = data.get("crc", "none")
         ecc = ECCCfg.from_dict(data.get("ecc"))


### PR DESCRIPTION
## Summary
- tighten arithmetic codec, crypto API, and CLI quality handling to satisfy mypy and preserve runtime validation
- add casting helpers, optional dependency guards, and clearer LM adapter state management across modules
- refresh CLI fallback encode/decode flows and dynamic transformers imports to play nicely with optional packages

## Testing
- `mypy src`
- `ruff check main.py src`
- `pytest` *(fails: optional cryptography dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea2ddda3388332bbf54503d259d7b6